### PR TITLE
canvas element width during zooms

### DIFF
--- a/src/JBrowse/View/Track/WiggleBase.js
+++ b/src/JBrowse/View/Track/WiggleBase.js
@@ -186,7 +186,11 @@ Wiggle.extend({
                 'canvas',
                 { height: canvasHeight,
                   width:  canvasWidth,
-                  style: { cursor: 'default' },
+                  style: {
+                      cursor: 'default',
+                      width: "100%", 
+                      height: canvasHeight + "px"
+                  },
                   innerHTML: 'Your web browser cannot display this type of track.',
                   className: 'canvas-track'
                 },


### PR DESCRIPTION
In the demos I've looked at, canvas elements in tracks don't scale with everything else during zoom transitions, leaving gaps (on zoom-in transitions) or overlaps (on zoom-outs).

Canvas elements have an internal notion of width and height, which are the pixel dimensions of the drawing area.  And, as HTML elements, they _also_ have CSS width and height properties, which do not have to correspond to the pixel dimensions of the drawing area.  In other words, canvas.width and canvas.style.width are semantically different and can be set independently.

This patch sets the CSS width of canvas elements to 100% so that they stretch and shrink with everything else during zooms.  I've barely tested it (only on Firefox) but it seems to do what I wanted.
