### PR TITLE
Stop doing 'require' in WebApollo/main.js.

### DIFF
--- a/plugins/WebApollo/js/main.js
+++ b/plugins/WebApollo/js/main.js
@@ -1,21 +1,10 @@
-require({
-           packages: [
-               { name: 'jqueryui', location: '../plugins/WebApollo/jslib/jqueryui' },
-               { name: 'jquery', location: '../plugins/WebApollo/jslib/jquery', main: 'jquery' }
-           ]
-       },
-       [],
-       function() {
-
-define.amd.jQuery = true;
-
 define(
        [
            'dojo/_base/declare',
            'dijit/CheckedMenuItem',
            'JBrowse/Plugin',
-           './FeatureEdgeMatchManager',
-	   './FeatureSelectionManager'
+           'WebApollo/FeatureEdgeMatchManager',
+	   'WebApollo/FeatureSelectionManager'
        ],
     function( declare, dijitCheckedMenuItem, JBPlugin, FeatureEdgeMatchManager, FeatureSelectionManager ) {
 


### PR DESCRIPTION
In the spirit of SHA: 4eed88d18d9d3f5a5bb4083e5750de1849f667a8.

This helps embed JB/WA in external applications.

Signed-off-by: Anurag Priyam anurag08priyam@gmail.com
