### PR TITLE
returning dominant strandedness for paired end reads

### DIFF
--- a/src/JBrowse/Store/SeqFeature/BAM/LazyFeature.js
+++ b/src/JBrowse/Store/SeqFeature/BAM/LazyFeature.js
@@ -123,10 +123,17 @@ var Feature = Util.fastDeclare(
         }
         return qseq.join(' ');
     },
+    /** if not paired then strand comes from seq_reverse_complemented
+        if paired and both forward then forward
+        if paired and both reverse then reverse
+        if paired and opposite then return 'next' strand ie dominant mate
+    **/
     strand: function() {
         var xs = this._get('xs');
         return xs ? ( xs == '-' ? -1 : 1 ) :
-               this._get('seq_reverse_complemented') ? -1 :  1;
+               (this._get('multi_segment_template') &&  this._get('multi_segment_last')) ?
+               (this._get('multi_segment_next_segment_reversed') ? -1 : 1) : 
+               (this._get('seq_reverse_complemented') ? -1 :  1);
     },
     /**
      * Length in characters of the read name.


### PR DESCRIPTION
Modification that would give the strandedness of each read according to dominant mate in a pair (if reads are paired). The modification seems to work fairly well when streaming. There may be a more appropriate place for modifying this e.g. create a dominant_strand function and associated options for coloring/sorting BAM.
