### PR TITLE
strand: XS tag is an aligner specified field and intention can clash (patch included).

### DIFF
--- a/src/JBrowse/Store/SeqFeature/BAM/LazyFeature.js
+++ b/src/JBrowse/Store/SeqFeature/BAM/LazyFeature.js
@@ -131,7 +131,7 @@ var Feature = Util.fastDeclare(
     },
     strand: function() {
         var xs = this._get('xs');
-        return xs ? ( xs == '-' ? -1 : 1 ) :
+        return xs && isNaN(xs) ? ( xs == '-' ? -1 : 1 ) :
                this._get('seq_reverse_complemented') ? -1 :  1;
     },
     multi_segment_next_segment_strand: function() {


### PR DESCRIPTION
It appears that the strand function was originally coded against XS
as 'sequence from strand', probably for RNA or some such.

BWA-mem defines XS as 'suboptimal alignment score' which is numeric
resulting in incorrect read colouring.

I've attempted to preserve original functionallity, however this may
give unexpected results should XS be used in a different textual way
by another tool.

Technically X?, Y?, Z? tags should not be baked into any BAM rendering components, see [BAM specification](http://samtools.github.io/hts-specs/SAMv1.pdf).

> Note that tags starting with `X', `Y' and `Z' or tags containing lowercase letters
in either position are reserved for local use and will not be formally defined in any future version of
this specication.