### PR TITLE
Strand Determined Consistently Relative to Reference Genome (see the FLAG rather than XS tag)

### DIFF
--- a/src/JBrowse/Store/SeqFeature/BAM/LazyFeature.js
+++ b/src/JBrowse/Store/SeqFeature/BAM/LazyFeature.js
@@ -130,9 +130,7 @@ var Feature = Util.fastDeclare(
         return qseq.join(' ');
     },
     strand: function() {
-        var xs = this._get('xs');
-        return xs ? ( xs == '-' ? -1 : 1 ) :
-               this._get('seq_reverse_complemented') ? -1 :  1;
+        return this._get('seq_reverse_complemented') ? -1 :  1;
     },
     multi_segment_next_segment_strand: function() {
       if(this._get('multi_segment_next_segment_unmapped'))

--- a/src/JBrowse/View/FeatureGlyph/Alignment.js
+++ b/src/JBrowse/View/FeatureGlyph/Alignment.js
@@ -34,7 +34,7 @@ return declare( [BoxGlyph,MismatchesMixin], {
                         return track.colorForBase('reference');
                       if(feature.get('multi_segment_template')) {
                         if(feature.get('multi_segment_all_correctly_aligned')) {
-                          if(feature.get('multi_segment_first'){
+                          if(feature.get('multi_segment_first')){
                             return  strand == 1  || strand == '+'
                                   ? glyph.getStyle( feature, 'color_fwd_strand' )
                                   : glyph.getStyle( feature, 'color_rev_strand' );
@@ -45,7 +45,7 @@ return declare( [BoxGlyph,MismatchesMixin], {
                           }
                         }
                         if(feature.get('multi_segment_next_segment_unmapped')) {
-                          if(feature.get('multi_segment_first'){
+                          if(feature.get('multi_segment_first')){
                             return  strand == 1  || strand == '+'
                                   ? glyph.getStyle( feature, 'color_fwd_missing_mate' )
                                   : glyph.getStyle( feature, 'color_rev_missing_mate' );
@@ -56,7 +56,7 @@ return declare( [BoxGlyph,MismatchesMixin], {
                           }
                         }
                         if(feature.get('seq_id') == feature.get('next_seq_id')) {
-                          if(feature.get('multi_segment_first'){
+                          if(feature.get('multi_segment_first')){
                             return  strand == 1  || strand == '+'
                                   ? glyph.getStyle( feature, 'color_fwd_strand_not_proper' )
                                   : glyph.getStyle( feature, 'color_rev_strand_not_proper' );

--- a/src/JBrowse/View/FeatureGlyph/Alignment.js
+++ b/src/JBrowse/View/FeatureGlyph/Alignment.js
@@ -34,19 +34,37 @@ return declare( [BoxGlyph,MismatchesMixin], {
                         return track.colorForBase('reference');
                       if(feature.get('multi_segment_template')) {
                         if(feature.get('multi_segment_all_correctly_aligned')) {
-                          return  strand == 1  || strand == '+'
+                          if(feature.get('multi_segment_first'){
+                            return  strand == 1  || strand == '+'
                                   ? glyph.getStyle( feature, 'color_fwd_strand' )
                                   : glyph.getStyle( feature, 'color_rev_strand' );
+                          }else{
+                            return  strand == 1  || strand == '+'
+                                  ? glyph.getStyle( feature, 'color_rev_strand' )
+                                  : glyph.getStyle( feature, 'color_fwd_strand' );
+                          }
                         }
                         if(feature.get('multi_segment_next_segment_unmapped')) {
-                          return  strand == 1  || strand == '+'
+                          if(feature.get('multi_segment_first'){
+                            return  strand == 1  || strand == '+'
                                   ? glyph.getStyle( feature, 'color_fwd_missing_mate' )
                                   : glyph.getStyle( feature, 'color_rev_missing_mate' );
+                          }else{
+                            return  strand == 1  || strand == '+'
+                                  ? glyph.getStyle( feature, 'color_rev_missing_mate' )
+                                  : glyph.getStyle( feature, 'color_fwd_missing_mate' );
+                          }
                         }
                         if(feature.get('seq_id') == feature.get('next_seq_id')) {
-                          return  strand == 1  || strand == '+'
+                          if(feature.get('multi_segment_first'){
+                            return  strand == 1  || strand == '+'
                                   ? glyph.getStyle( feature, 'color_fwd_strand_not_proper' )
                                   : glyph.getStyle( feature, 'color_rev_strand_not_proper' );
+                          }else{
+                            return  strand == 1  || strand == '+'
+                                  ? glyph.getStyle( feature, 'color_rev_strand_not_proper' )
+                                  : glyph.getStyle( feature, 'color_fwd_strand_not_proper' );
+                          }
                         }
                         // should only leave aberrant chr
                         return  strand == 1  || strand == '+'


### PR DESCRIPTION
When viewing a BAM file of stranded RNA-seq data with JBrowse, the color of reads spanning an intron were shown with different color than other reads.  Further looking the description, the strand are shown inconsistently, the read on an intron the strand is maked as relative to the transcript rather than the reference genome.

The cause of such behavior is that it looks on the XS tag if present, while in absence of XS tag it looks the FLAG.  This makes inconsistent view. The patch attached does not check the XS tag and consistently follow the FLAG and therefore the strand is relative to genome.

Looking XS tag in itself could be a good thing. However, in that case, unknown should be treated as unknown.  Having a switch to change the view between relative to transcript and relative to genome could worth to implement. But, that is beyond the scope of this pull request. Thank you.