### PR TITLE
Support for indexed fasta files as reference sequences

### DIFF
--- a/bin/prepare-refseqs.pl
+++ b/bin/prepare-refseqs.pl
@@ -20,6 +20,8 @@ prepare-refseqs.pl - format reference sequences for use by JBrowse
    # OR:
        prepare-refseqs.pl --fasta <file1> --fasta <file2>  [options]
    # OR:
+       prepare-refseqs.pl --indexed_fasta <file1>  [options]
+   # OR:
        prepare-refseqs.pl --conf <JBrowse config file>  [options]
    # OR:
        prepare-refseqs.pl --sizes <sizes file>  [options]
@@ -57,6 +59,11 @@ information.
 
 A FASTA file, optionally gzipped from which to load reference
 sequences.
+
+=item --indexed_fasta <file>
+
+A FASTA file (which should already have an accompaning '.fai' file)
+from which to load reference sequences.
 
 =item --conf <file>
 

--- a/src/JBrowse/Store/SeqFeature/IndexedFasta.js
+++ b/src/JBrowse/Store/SeqFeature/IndexedFasta.js
@@ -1,0 +1,95 @@
+define( [ 'dojo/_base/declare',
+          'dojo/_base/lang',
+          'dojo/request',
+          'dojo/promise/all',
+          'dojo/Deferred',
+          'JBrowse/Store/SeqFeature',
+          'JBrowse/Util',
+          'JBrowse/Model/SimpleFeature',
+          'JBrowse/Digest/Crc32',
+          'JBrowse/Model/XHRBlob',
+        ],
+        function(
+            declare,
+            lang,
+            request,
+            all,
+            Deferred,
+            SeqFeatureStore,
+            Util,
+            SimpleFeature,
+            Crc32,
+            XHRBlob
+        ) {
+
+return declare( SeqFeatureStore,
+{
+
+/**
+ * Storage backend for sequences in indexed fasta files
+ * served as static text files.
+ * @constructs
+ */
+    constructor: function(args) {
+        this.fasta = new XHRBlob( this.resolveUrl( args.urlTemplate ));
+		this.index = {}
+
+        var thisO = this;
+		this.index_promise = request( this.resolveUrl( args.urlTemplateFAI || args.urlTemplate + '.fai' ) ).then( function( text ) {
+			text.split(/\r?\n/).forEach( function ( line ) {
+				var row = line.split('\t');
+				thisO.index[row[0]] = {
+					'name': row[0],
+					'length': +row[1],
+					'offset': +row[2],
+					'linelen': +row[3],
+					'linebytelen': +row[4]
+				};
+			});
+		}, function( err ) {
+			console.log(err);
+		});
+    },
+
+    getFeatures: function( query, featureCallback, endCallback, errorCallback ) {
+
+		var idxF = this;
+		errorCallback = errorCallback || function(e) { console.error(e); };
+
+		var refname = query.ref;
+		if( ! this.browser.compareReferenceNames( this.refSeq.name, refname ) )
+			refname = this.refSeq.name;
+
+		this.index_promise.then( function ( data ) {
+			var refindex = idxF.index[refname];
+			var offset = idxF._fai_offset(refindex, query.start);
+			var readlen = idxF._fai_offset(refindex, query.end) - offset;
+
+			idxF.fasta.read(offset, readlen,
+				function (data) {
+					featureCallback(
+						new SimpleFeature({
+						  data: {
+							  start:    query.start,
+							  end:      query.end,
+							  residues: String.fromCharCode.apply(null, new Uint8Array(data)).replace(/\s+/g, ''),
+							  seq_id:   refname,
+							  name:     refname
+						  }
+						})
+					);
+					endCallback();
+				},
+				function (err) {
+					errorCallback(err)
+				}
+			);
+		});
+    },
+
+    _fai_offset: function(idx, pos) {
+        return idx.offset + idx.linebytelen * Math.floor(pos / idx.linelen) + pos % idx.linelen;
+    }
+
+});
+});

--- a/src/JBrowse/Store/SeqFeature/SequenceChunks.js
+++ b/src/JBrowse/Store/SeqFeature/SequenceChunks.js
@@ -48,8 +48,7 @@ return declare( SeqFeatureStore,
         if( ! this.browser.compareReferenceNames( this.refSeq.name, refname ) )
             refname = this.refSeq.name;
 
-        var chunkSize  = query.seqChunkSize
-            || refname == this.refSeq.name && this.refSeq.seqChunkSize
+        var chunkSize  = ( refname == this.refSeq.name && this.refSeq.seqChunkSize )
             || this.seqChunkSize
             || ( this.compress ? 80000 : 20000 );
 

--- a/src/JBrowse/View/Track/Sequence.js
+++ b/src/JBrowse/View/Track/Sequence.js
@@ -88,7 +88,6 @@ return declare( [BlockBased, ExportMixin],
             this.store.getReferenceSequence(
                 {
                     ref: this.refSeq.name,
-                    seqChunkSize: this.refSeq.seqChunkSize,
                     start: leftExtended,
                     end: rightExtended
                 },


### PR DESCRIPTION
Addressing issue #317

This could be implemented may different ways, I just made it so that the fasta file and index (<fasta_file>.fai) end up in the seq directory, and the fai is used to determine the offsets for loading the sequence.

There is no explicit chunk size, but this uses XHRBlob which downloads in 64kb chunks.

There is no support for compressed fasta files. This would be doable-- it would require additional preparation-- specifically bgzipping the fasta file and making a file which contains offsets to bgzf blocks.