### PR TITLE
fix bug on --refs option

### DIFF
--- a/src/perl5/Bio/JBrowse/Cmd/FormatSequences.pm
+++ b/src/perl5/Bio/JBrowse/Cmd/FormatSequences.pm
@@ -178,7 +178,7 @@ sub exportFASTA {
         }
 
         my $curr_seq;
-        my $curr_chunk;
+        my $curr_chunk = '';
         my $chunk_num;
 
         my $noseq = $self->opt('noseq');


### PR DESCRIPTION
Hello,

While trying to use the --refs parameters with --fasta options, I've got fatal errors (on the $refs hash and the uninitialized current_chunk variable).
The following code had fixed the bug.
Could you please apply this path.

Regards!
