### PR TITLE
Added a Log scale toggle to the Wiggle track menu

### DIFF
--- a/src/JBrowse/View/Track/WiggleBase.js
+++ b/src/JBrowse/View/Track/WiggleBase.js
@@ -560,6 +560,20 @@ return declare( [BlockBasedTrack,ExportMixin, DetailStatsMixin ], {
             }
         });
 
+        options.push({
+            label: 'Log scale',
+            type: 'dijit/CheckedMenuItem',
+            checked: !!(this.config.scale == 'log'),
+            onClick: function(event) {
+                if (this.checked) {
+                    track.config.scale = 'log';
+                } else {
+                    track.config.scale = 'linear';
+                }
+                track.browser.publish('/jbrowse/v1/v/tracks/replace', [track.config]);
+            }
+        });
+
         return options;
     },
 


### PR DESCRIPTION
The design is that when Log scale is toggled on, the mouse over pixel values still display the original value.