### PR TITLE
Wiggle tracks now shows pixel values of 0 on mouse over

### DIFF
--- a/src/JBrowse/View/Track/WiggleBase.js
+++ b/src/JBrowse/View/Track/WiggleBase.js
@@ -528,7 +528,7 @@ return declare( [BlockBasedTrack,ExportMixin, DetailStatsMixin ], {
             scoreDisplay.innerHTML = parseFloat( score.toPrecision(6) );
             return true;
         }
-        else if( score && score['score'] && typeof score['score'] == 'number' ) {
+        else if( score && typeof score['score'] == 'number' ) {
             // "score" may be an object.
             scoreDisplay.innerHTML = parseFloat( score['score'].toPrecision(6) );
             return true;


### PR DESCRIPTION
This fixes the problem when using binary 0/1 tracks, zeros were not being displayed.