### PR TITLE
Wiggle tracks now calculate averages instead of max when multiple points...

### DIFF
--- a/src/JBrowse/View/Track/WiggleBase.js
+++ b/src/JBrowse/View/Track/WiggleBase.js
@@ -394,7 +394,7 @@ return declare( [BlockBasedTrack,ExportMixin, DetailStatsMixin ], {
     },
 
     _calculatePixelScores: function( canvasWidth, features, featureRects ) {
-        // make an array of the max score at each pixel on the canvas
+        // make an array of the average score at each pixel on the canvas
         var pixelValues = new Array( canvasWidth );
         dojo.forEach( features, function( f, i ) {
             var store = f.source;
@@ -402,24 +402,31 @@ return declare( [BlockBasedTrack,ExportMixin, DetailStatsMixin ], {
             var jEnd = fRect.r;
             var score = f.get('score');
             for( var j = Math.round(fRect.l); j < jEnd; j++ ) {
-                if ( pixelValues[j] && pixelValues[j]['lastUsedStore'] == store ) {
-                    /* Note: if the feature is from a different store, the condition should fail,
-                     *       and we will add to the value, rather than adjusting for overlap */
-                    pixelValues[j]['score'] = Math.max( pixelValues[j]['score'], score );
+                // bin scores according to store
+                if ( pixelValues[j] && store in pixelValues[j]['scores'] ) {
+                    pixelValues[j]['scores'][store].push(score);
                 }
                 else if ( pixelValues[j] ) {
-                    pixelValues[j]['score'] = pixelValues[j]['score'] + score;
-                    pixelValues[j]['lastUsedStore'] = store;
+                    pixelValues[j]['scores'][store] = [score];
                 }
                 else {
-                    pixelValues[j] = { score: score, lastUsedStore: store, feat: f };
+                    pixelValues[j] = { scores: {}, feat: f };
+                    pixelValues[j]['scores'][store] = [score];
                 }
             }
         },this);
-        // when done looping through features, forget the store information.
+        // when done looping through features, average the scores in the same store then add them all together as the final score
         for (var i=0; i<pixelValues.length; i++) {
             if ( pixelValues[i] ) {
-                delete pixelValues[i]['lastUsedStore'];
+                pixelValues[i]['score'] = 0;
+                for (store in pixelValues[i]['scores']) {
+                    var j, sum = 0, len = pixelValues[i]['scores'][store].length;
+                    for (j = 0; j < len; j++) {
+                        sum += pixelValues[i]['scores'][store][j];
+                    }
+                    pixelValues[i]['score'] += sum / len;
+                }
+                delete pixelValues[i]['scores'];
             }
         }
         return pixelValues;


### PR DESCRIPTION
Wiggle tracks now calculate averages instead of max when multiple points map to a single pixel, this fixes the display issue under certain zoom levels when using wiggle tracks to display GC content, and correctly calculates the average GC percentage when zooming out.