### PR TITLE
Batch versions of addFeatures, addTracks and addStores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ samtools-master/
 samtools-0.1.20
 setup.log
 MYMETA.*
+test_*

--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "src/FileSaver"]
 	path = src/FileSaver
 	url = git://github.com/dkasenberg/FileSaver.js.git
+[submodule "htslib"]
+        path = htslib
+        url = git://github.com:samtools/htslib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -38,5 +38,5 @@
 	path = src/FileSaver
 	url = git://github.com/dkasenberg/FileSaver.js.git
 [submodule "htslib"]
-        path = htslib
-        url = git://github.com:samtools/htslib.git
+	path = htslib
+	url = git@github.com:samtools/htslib.git

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
                       JBrowse = new Browser( cfg );
                     }
 
-                   if( queryParams.addFeaturesBatch || queryParams.addTracksBatch || queryParams.addStoresBatch ) {
+                   if( queryParams.addFeaturesBatch || queryParams.addTracksBatch || queryParams.addStoresBatch || queryParams.addAllBatch) {
                       console.log("has batch");
                       if (typeof(queryParams.addFeaturesBatch) == 'undefined' ) {
                         queryParams.addFeaturesBatch = null;
@@ -93,6 +93,9 @@
                       }
                       if (typeof(queryParams.addStoresBatch) == 'undefined' ) {
                         queryParams.addStoresBatch = null;
+                      }
+                      if (typeof(queryParams.addAllBatch) == 'undefined' ) {
+                        queryParams.addAllBatch = null;
                       }
                       
                       
@@ -107,7 +110,7 @@
                       }                      
 
                       
-                      load_batches( config, queryParams.addFeaturesBatch, queryParams.addTracksBatch, queryParams.addStoresBatch, function(){ start_jbrowse(config); } )
+                      load_batches( config, queryParams.addFeaturesBatch, queryParams.addTracksBatch, queryParams.addStoresBatch, queryParams.addAllBatch, function(){ start_jbrowse(config); } )
                    } else {
                       console.log("no batch");
                       start_jbrowse(config);
@@ -117,7 +120,7 @@
       
       
       
-        function load_batches( config, addFeaturesBatch, addTracksBatch, addStoresBatch, callback ) {
+        function load_batches( config, addFeaturesBatch, addTracksBatch, addStoresBatch, addAllBatch, callback ) {
           console.log("config.stores.url.features", config.stores.url.features);
           console.log("config.tracks"             , config.tracks);
           console.log("config.stores"             , config.stores);
@@ -161,9 +164,35 @@
                 } else {
                   console.log("no store to parse");
                 }
-                
-                console.log("starting JBrowse", "config.stores.url.features", config.stores.url.features, "config.tracks", config.tracks, "config.stores", config.stores);
-                callback();
+  
+  
+  
+                console.log("loading all batch", addAllBatch);
+                load_json( addAllBatch       , function(res4){ 
+                  console.log("loaded all batch", addAllBatch, "res", res4);
+                  if (res4 != null) {
+                    console.log("parsing all batch", res4);
+                    
+                    config.stores.url.features += res4['features'].join(',');
+                    
+                    for ( var t in res4['tracks'] ) {
+                      console.log("t", res4['tracks'][t]);
+                      config.tracks.push(res4['tracks'][t]);
+                    }
+
+
+                    for ( var s in res4['stores'] ) {
+                      console.log("s", res4['stores'][s]);
+                      config.stores[s] = res4['stores'][s];
+                    }
+                    
+                  } else {
+                    console.log("no all to parse");
+                  }
+                  
+                  console.log("starting JBrowse", "config.stores.url.features", config.stores.url.features, "config.tracks", config.tracks, "config.stores", config.stores);
+                  callback();
+                } )
               } );
             } );
           } );
@@ -187,14 +216,14 @@
           
           if ( url == null ) {
             console.log("load_json: url is null");
-            load(null);
+            clbk(null);
           } else {
             console.log("load_json: url is not null");
             dojo.xhrGet({ url     : url,
                           handleAs: "jsoni",
                           failOk  : true,
                           load    : clbk,
-                          error   : function( url ) { _alert("failed to load url: "+url); load(null); }
+                          error   : function( url ) { _alert("failed to load url: "+url); clbk(null); }
                      });
           }
         }

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" type="text/css" href="genome.css">
     <script type="text/javascript" src="src/dojo/dojo.js" data-dojo-config="async: 1, baseUrl: './src'"></script>
     <script type="text/javascript" src="src/JBrowse/init.js"></script>
-
     <script type="text/javascript">
         window.onerror=function(msg){
             if( document.body )
@@ -79,11 +78,116 @@
                        config.stores = JSON.parse( queryParams.addStores );
                    }
 
-                   // create a JBrowse global variable holding the JBrowse instance
-                   JBrowse = new Browser( config );
-        });
-    </script>
+                    function start_jbrowse(cfg) {
+                      // create a JBrowse global variable holding the JBrowse instance
+                      JBrowse = new Browser( cfg );
+                    }
 
+                   if( queryParams.addFeaturesBatch || queryParams.addTracksBatch || queryParams.addStoresBatch ) {
+                      console.log("has batch");
+                      if (typeof(queryParams.addFeaturesBatch) == 'undefined' ) {
+                        queryParams.addFeaturesBatch = null;
+                      }
+                      if (typeof(queryParams.addTracksBatch) == 'undefined' ) {
+                        queryParams.addTracksBatch = null;
+                      }
+                      if (typeof(queryParams.addStoresBatch) == 'undefined' ) {
+                        queryParams.addStoresBatch = null;
+                      }
+                      
+                      
+                      if (typeof(config.stores.url.features) == 'undefined' ) {
+                        config.stores.url.features = '';
+                      }
+                      if (typeof(config.tracks) == 'undefined' ) {
+                        config.tracks = [];
+                      }                      
+                      if (typeof(config.stores) == 'undefined' ) {
+                        config.stores = {};
+                      }                      
+
+                      
+                      load_batches( config, queryParams.addFeaturesBatch, queryParams.addTracksBatch, queryParams.addStoresBatch, function(){ start_jbrowse(config); } )
+                   } else {
+                      console.log("no batch");
+                      start_jbrowse(config);
+                   }
+        });
+      
+      
+      
+      
+        function load_batches( config, addFeaturesBatch, addTracksBatch, addStoresBatch, callback ) {
+          console.log("config.stores.url.features", config.stores.url.features);
+          console.log("config.tracks"             , config.tracks);
+          console.log("config.stores"             , config.stores);
+          
+          console.log("loading feature batch", addFeaturesBatch);
+          load_json( addFeaturesBatch, function(res1){
+            console.log("loaded feature batch", addFeaturesBatch, "res", res1);
+            if (res1 != null) {
+              console.log("parsing feature batch", res1);
+              config.stores.url.features += res1.join(',');
+            } else {
+              console.log("no feature to parse");
+            }
+            
+
+            console.log("loading tracks batch", addTracksBatch);
+            load_json( addTracksBatch  , function(res2){
+              console.log("loaded tracks batch", addTracksBatch, "res", res2);
+              if (res2 != null) {
+                console.log("parsing tracks batch", res2);
+                
+                for ( var t in res2 ) {
+                  console.log("t", res2[t]);
+                  config.tracks.push(res2[t]);
+                }
+
+              } else {
+                console.log("no track to parse");
+              }
+              
+
+              console.log("loading stores batch", addStoresBatch);
+              load_json( addStoresBatch       , function(res3){ 
+                console.log("loaded stores batch", addStoresBatch, "res", res3);
+                if (res3 != null) {
+                  console.log("parsing stores batch", res3);
+                  for ( var s in res3 ) {
+                    console.log("s", res3[s]);
+                    config.stores[s] = res3[s];
+                  }
+                } else {
+                  console.log("no store to parse");
+                }
+                
+                console.log("starting JBrowse", "config.stores.url.features", config.stores.url.features, "config.tracks", config.tracks, "config.stores", config.stores);
+                callback();
+              } );
+            } );
+          } );
+        }
+
+        function load_json( url, load ) {
+          if ( url == null ) {
+            console.log("load_json: url is null");
+            load(null);
+          } else {
+            console.log("load_json: url is not null");
+            dojo.xhrGet({ url     : url,
+                          handleAs: "json",
+                          failOk  : true,
+                          load    : load,
+                          error   : function( url ) { _alert("failed to load url: "+url); load(null); }
+                     });
+          }
+        }
+        
+        function _alert( msg ) {
+          alert(msg);
+        }
+    </script>
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -169,16 +169,31 @@
           } );
         }
 
-        function load_json( url, load ) {
+        function load_json( url, clbk ) {
+          // create a new json handler for dojo.xhrGet (jsoni - insecure json)
+          dojo.contentHandlers.jsoni = function(xhr) {
+            // summary: A contentHandler which returns a JavaScript object created from the response data after extra verification on the JSON structure
+            if (typeof JSON === 'object' && typeof JSON.parse === 'function') {
+              // if has native JSON.parse, use secure JSON.parse
+              //fromJson has a second argument which will force extra scrutiny
+              //on the JSON string
+              return _d.fromJson(xhr.responseText || null, true);
+            } else {
+              // else, do not attempt to parse
+              return null;
+            }
+          }
+          
+          
           if ( url == null ) {
             console.log("load_json: url is null");
             load(null);
           } else {
             console.log("load_json: url is not null");
             dojo.xhrGet({ url     : url,
-                          handleAs: "json",
+                          handleAs: "jsoni",
                           failOk  : true,
-                          load    : load,
+                          load    : clbk,
                           error   : function( url ) { _alert("failed to load url: "+url); load(null); }
                      });
           }


### PR DESCRIPTION
This pull request adds the batch options for addFeatures, addTracks and addStores allowing for 3 JSON files to be passed in the URI.

addFeaturesBatch=test_features.json&addTracksBatch=test_tracks.json&addStoresBatch=test_stores.json

This circumvents the 4000 characters limit for URIs.

==> test_features.json <==
[
    "t_label"
]

==> test_stores.json <==
{
    "s_name": {
        "type":"JBrowse/Store/SeqFeature/GFF3",
        "urlTemplate":"http://url.gff3"
    }
}

==> test_tracks.json <==
[
    {
        "label": "t_label",
        "store": "s_name",
        "type" : "JBrowse/View/Track/CanvasFeatures",
        "style": {
            "color": "red"
        }
    }
]
