### PR TITLE
Add a View menu item for Show/hide track labels

### DIFF
--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -5,6 +5,7 @@ define( [
             'dojo/_base/lang',
             'dojo/on',
             'dojo/html',
+            'dojo/query', 
             'dojo/dom-construct',
             'dojo/keys',
             'dojo/Deferred',
@@ -23,6 +24,7 @@ define( [
             'dijit/form/ToggleButton',
             'dijit/form/DropDownButton',
             'dijit/DropDownMenu',
+            'dijit/CheckedMenuItem',
             'dijit/MenuItem',
             'dijit/MenuSeparator',
             'dojox/form/TriStateCheckBox',
@@ -53,6 +55,7 @@ define( [
             lang,
             on,
             html,
+            query,
             domConstruct,
             keys,
             Deferred,
@@ -71,6 +74,7 @@ define( [
             dijitToggleButton,
             dijitDropDownButton,
             dijitDropDownMenu,
+            dijitCheckedMenuItem,
             dijitMenuItem,
             dijitMenuSeparator,
             dojoxTriStateCheckBox,
@@ -697,6 +701,18 @@ initView: function() {
                 }
             }));
 
+            this._showLabels=(this.cookie("showTrackLabel")||"true")=="true"                                             
+            this.addGlobalMenuItem( 'view', new dijitCheckedMenuItem(                                                     
+                {                                                                                                       
+                    label: "Show track label",                                                                          
+                    checked: this._showLabels,                                                                          
+                    onClick: function(event) {                                                                          
+                        thisObj._showLabels=this.get("checked");                                                          
+                        thisObj.cookie("showTrackLabel",this.get("checked")?"true":"false");                            
+                        thisObj.updateLabels();                                                                           
+                    }                                                                                                   
+                }));
+
             this.renderGlobalMenu( 'view', {text: 'View'}, menuBar );
 
             // make the options menu
@@ -803,7 +819,15 @@ initView: function() {
         }));
     });
 },
-
+updateLabels: function() {                                                                                          
+    if(!this._showLabels) {                                                                                         
+        query('.track-label').style('visibility','hidden');                                                         
+    }                                                                                                               
+    else {                                                                                                          
+        query('.track-label').style('visibility','visible');                                                        
+    }                                                                                                               
+    this.view.updateScroll();                                                                               
+},
 createCombinationTrack: function() {
     if(this._combinationTrackCount === undefined) this._combinationTrackCount = 0;
     var d = new Deferred();

--- a/src/JBrowse/View/Track/HTMLFeatures.js
+++ b/src/JBrowse/View/Track/HTMLFeatures.js
@@ -313,6 +313,7 @@ var HTMLFeatures = declare( [ BlockBased, YScaleMixin, ExportMixin, FeatureDetai
     },
 
     updateFeatureLabelPositions: function( coords ) {
+        var showLabels=this.browser._showLabels;
         if( ! 'x' in coords )
             return;
 
@@ -324,7 +325,7 @@ var HTMLFeatures = declare( [ BlockBased, YScaleMixin, ExportMixin, FeatureDetai
             // width
             if( ! block || ! this.label )
                 return;
-            var viewLeft = 100 * ( (this.label.offsetLeft+this.label.offsetWidth) - block.domNode.offsetLeft ) / block.domNode.offsetWidth + 2;
+            var viewLeft = 100 * ( (this.label.offsetLeft+(showLabels?this.label.offsetWidth:0)) - block.domNode.offsetLeft ) / block.domNode.offsetWidth + 2;
 
             // if the view start is unknown, or is to the
             // left of this block, we don't have to worry


### PR DESCRIPTION
This adds the ability to show or hide track labels with a checkbox


We had added this feature to WebApollo 1.x awhile back, but I felt this functionality can also be backported to JBrowse core


I'm not sure if this affects the HideTrackLabels plugin but I thought that having it as a simple menu item can help users too


![screenshot-localhost 2015-11-24 12-34-30 png resize](https://cloud.githubusercontent.com/assets/6511937/11376704/dcc0ecd6-92a7-11e5-86c8-2367598ea179.png)

![screenshot-localhost 2015-11-24 12-33-28 png resize](https://cloud.githubusercontent.com/assets/6511937/11376708/dfd72ba6-92a7-11e5-967f-a363e686962b.png)

