### PR TITLE
Add option to disable pre-flight request for SPARQL store

### DIFF
--- a/src/JBrowse/Store/SeqFeature/SPARQL.js
+++ b/src/JBrowse/Store/SeqFeature/SPARQL.js
@@ -86,11 +86,17 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, GlobalStatsEstimationMixi
     getFeatures: function( query, featCallback, finishCallback, errorCallback ) {
         if( this.queryTemplate ) {
             var thisB = this;
+            var headers = { "Accept": "application/json" };
+            if(this.config.disablePreflight) {
+                // https://www.sitepen.com/blog/2014/01/15/faq-cors-with-dojo/
+                headers["X-Requested-With"] = null;
+            }
+
             xhr.get( this.url+'?'+ioQuery.objectToQuery({
                                                             query: this._makeQuery( query )
                                                         }),
                      {
-                          headers: { "Accept": "application/json" },
+                          headers: headers,
                           handleAs: "json",
                           failOk: true
                      })


### PR DESCRIPTION
Sometimes data providers reject the CORS preflight request, so this adds an option for disabling that, in particular for SPARQL data stores


This dojo FAQ page discusses the technique https://www.sitepen.com/blog/2014/01/15/faq-cors-with-dojo/


The Apollo hackathon uncovered that this patch was needed for a wikidata query

Ideally the data provider i.e. wikidata would accept the CORS request out of the box, but this seems like a needed workaround