### PR TITLE
Allow specifying custom exporter classes outside the JBrowse namespace

### DIFF
--- a/src/JBrowse/View/Track/_ExportMixin.js
+++ b/src/JBrowse/View/Track/_ExportMixin.js
@@ -277,8 +277,7 @@ return declare( null, {
                           + "currently-visible reference sequence" );
             return;
         }
-
-        require( ['JBrowse/View/Export/'+format], dojo.hitch(this,function( exportDriver ) {
+        require( [format.match(/\//)?format:'JBrowse/View/Export/'+format], dojo.hitch(this,function( exportDriver ) {
             new exportDriver({
                 refSeq: this.refSeq,
                 track: this,


### PR DESCRIPTION
We saw a scenario where one of our track types had a quirk with "Save track data" and I thought that it would be useful to have the ability to specify a custom exporter class.

This PR simply checks whether the name of the class that is specified by the track type contains slashes, and if it does, then we assume it is a full path to a exporter module rather than something that already exists in JBrowse namespace.


For example, I could have a class like this that inherits from the default gff3 exporter


```
define([
            "dojo/_base/declare",
            "JBrowse/View/Export/GFF3"
       ],
       function(
            declare,
            ExportGFF3
       ) {
return declare(ExportGFF3, {

    constructor: function() {
        console.log("Initialized");
    },
    writeFeature: function(feature) { /* do custom exporter things... */ }
});

});

```

And then use it for some custom trackType by overriding _exportFormats


    _exportFormats: function() {
        return [ {name: 'WebApollo/View/Export/CustomExporter', label: 'GFF sequence alterations', fileExt: 'gff3'} ];
    }

