### PR TITLE
Don't overlap sequence with label

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -353,6 +353,10 @@ div.track.pinned {
     margin-bottom: -3px;
 }
 
+.track div.block {
+    margin-top: 25px;
+}
+
 div#static_track {
     top: 0px;
     position: absolute;

--- a/css/main.css
+++ b/css/main.css
@@ -353,7 +353,7 @@ div.track.pinned {
     margin-bottom: -3px;
 }
 
-.track div.block {
+.track.track_jbrowse_view_track_sequence div.block {
     margin-top: 25px;
 }
 


### PR DESCRIPTION
So this has annoyed me for a long time: the sequence is completely illegible, covered up by the track

![selection_599](https://cloud.githubusercontent.com/assets/458683/12901829/4e5ba1a8-ce83-11e5-8590-5ade6b897241.png)

Mildly better with translation on

![selection_598](https://cloud.githubusercontent.com/assets/458683/12901843/5d24f73e-ce83-11e5-8787-88dbadabb0f1.png)

But adding just 25px to the top of each track fixes this completely:

![selection_597](https://cloud.githubusercontent.com/assets/458683/12901866/65c1cf34-ce83-11e5-9377-85847e4298e2.png)
![selection_600](https://cloud.githubusercontent.com/assets/458683/12901875/773dfe04-ce83-11e5-85a9-e65fcf5ddb2c.png)

I recognise that I can override CSS locally and the community may not be interested in this PR, feel free to close if that's the case :)
