### PR TITLE
Adjusted faceted track selector tab's height

### DIFF
--- a/css/faceted_track_selector.css
+++ b/css/faceted_track_selector.css
@@ -123,7 +123,7 @@
 
 #faceted_tracksel .faceted_tracksel_on_off.tab {
     position: absolute;
-    top: 5em;
+    top: 12em;
     left: 100%;
     z-index: 5;
 

--- a/src/JBrowse/GenomeView.js
+++ b/src/JBrowse/GenomeView.js
@@ -630,7 +630,7 @@ scrollBarClickScroll : function( event ) {
 
     if ( absY > event.clientY )
       this.setY( this.getY() - 40 );
-    else if (absY + markerHeight < event.clientY){
+    else if (absY + markerHeight < event.clientY)
       this.setY( this.getY() + 40 );
 
     //the timeout is so that we don't have to run showVisibleBlocks

--- a/src/JBrowse/GenomeView.js
+++ b/src/JBrowse/GenomeView.js
@@ -423,6 +423,8 @@ _behaviors: function() { return {
             handles.push(
                 dojo.connect( this.scrollContainer,     wheelevent,     this, 'wheelScroll', false ),
 
+                dojo.connect( this.verticalScrollBar.container,     'onclick',     this, 'scrollBarClickScroll', false ),
+
                 dojo.connect( this.scaleTrackDiv,       "mousedown",
                               dojo.hitch( this, 'startRubberZoom',
                                           dojo.hitch( this,'absXtoBp'),
@@ -610,6 +612,43 @@ calculatePositionLabelHeight: function( containerElement ) {
     var h = heightTest.clientHeight;
     containerElement.removeChild(heightTest);
     return h;
+},
+
+scrollBarClickScroll : function( event ) {
+
+    if ( !event )
+        event = window.event;
+    // if( window.WheelEvent )
+    //     event = window.WheelEvent;
+
+    // 40 pixels per mouse click on scroll
+
+    var containerHeight = parseInt( this.verticalScrollBar.container.style.height,10 );
+    var markerHeight = parseInt( this.verticalScrollBar.positionMarker.style.height,10 );
+    var trackContainerHeight = this.trackContainer.clientHeight;
+    var absY = this.getY()*( trackContainerHeight/containerHeight );
+
+    if ( absY > event.clientY )
+      this.setY( this.getY() - 40 );
+    else if (absY + markerHeight < event.clientY){
+      this.setY( this.getY() + 40 );
+
+    //the timeout is so that we don't have to run showVisibleBlocks
+    //for every scroll wheel click (we just wait until so many ms
+    //after the last one).
+
+    if ( this.wheelScrollTimeout )
+        window.clearTimeout( this.wheelScrollTimeout );
+
+    // 100 milliseconds since the last scroll event is an arbitrary
+    // cutoff for deciding when the user is done scrolling
+    // (set by a bit of experimentation)
+    this.wheelScrollTimeout = window.setTimeout( dojo.hitch( this, function() {
+        this.showVisibleBlocks(true);
+        this.wheelScrollTimeout = null;
+    }, 100));
+
+    dojo.stopEvent(event);
 },
 
 wheelScroll: function( event ) {


### PR DESCRIPTION
Solved the issue #601 'Main Genome View page up/down scroll function doesn't function'
Now we can scroll by clicking the region above/below the scroll drag bar.

Also, moved the tab a little below solving issue. #680 

![screenshot from 2016-03-04 22-20-36](https://cloud.githubusercontent.com/assets/8681754/13533660/5cf0d728-e257-11e5-95aa-302077b8bf8b.png)

![screenshot from 2016-03-04 14-29-52](https://cloud.githubusercontent.com/assets/8681754/13533582/1a65fe60-e257-11e5-8fa7-d555934e5369.png)
