### PR TITLE
Fix alignment of buttons for #680

### DIFF
--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -2847,7 +2847,7 @@ cookie: function(keyWithoutId,value) {
 
 createNavBox: function( parent ) {
     var thisB = this;
-    var align = 'left';
+    var align = 'center';
     var navbox = dojo.create( 'div', { id: 'navbox', style: { 'text-align': align } }, parent );
 
     // container adds a white backdrop to the locationTrap.


### PR DESCRIPTION
The alignment of the menubar buttons looks like it can be fixed by changing the text-align CSS property

It looks ok with both locationBar = separate and default


![screenshot-localhost 2016-04-01 15-12-22](https://cloud.githubusercontent.com/assets/6511937/14218820/3b79c520-f81c-11e5-951a-8e12656fd177.png)
![screenshot-localhost 2016-04-01 15-12-04](https://cloud.githubusercontent.com/assets/6511937/14218821/3b85598a-f81c-11e5-8117-62226fa8cb55.png)