### PR TITLE
Add configurable timeout and handle the dataoverflow error during stats estimation

### DIFF
--- a/src/JBrowse/Store/SeqFeature.js
+++ b/src/JBrowse/Store/SeqFeature.js
@@ -20,6 +20,7 @@ return declare( Store,
 
     constructor: function( args ) {
         this.globalStats = {};
+        this.storeTimeout = args.storeTimeout || 500;
     },
 
     _evalConf: function( confVal, confKey ) {

--- a/src/JBrowse/Store/SeqFeature/BAM.js
+++ b/src/JBrowse/Store/SeqFeature/BAM.js
@@ -85,6 +85,8 @@ var BAMStore = declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesM
                                  }),
             failure: lang.hitch( this, '_failAllDeferred' )
         });
+
+        this.storeTimeout = args.storeTimeout || 3000;
     },
 
     /**

--- a/src/JBrowse/Store/SeqFeature/BigWig.js
+++ b/src/JBrowse/Store/SeqFeature/BigWig.js
@@ -61,6 +61,8 @@ return declare([ SeqFeatureStore, DeferredFeaturesMixin, DeferredStatsMixin ],
 
         this.name = args.name || ( this.data.url && new urlObj( this.data.url ).path.replace(/^.+\//,'') ) || 'anonymous';
 
+        this.storeTimeout = 3000;
+
         this._load();
     },
 

--- a/src/JBrowse/Store/SeqFeature/GlobalStatsEstimationMixin.js
+++ b/src/JBrowse/Store/SeqFeature/GlobalStatsEstimationMixin.js
@@ -51,7 +51,7 @@ return declare( null, {
 
         var maybeRecordStats = function( interval, stats, error ) {
             if( error ) {
-                if(error.isInstanceOf(Errors.DataOverflow)) {
+                if( error.isInstanceOf(Errors.DataOverflow) ) {
                      console.log( 'Store statistics found chunkSizeLimit error, using empty: '+(this.source||this.name) );
                      deferred.resolve( { featureDensity: 0, error: 'global stats estimation found chunkSizeError' } );
                 }
@@ -59,8 +59,8 @@ return declare( null, {
                     deferred.reject( error );
                 }
             } else {
-                var refLen = refseq.end - refseq.start;
-                 if( stats._statsSampleFeatures >= 300 || error ) {
+                 var refLen = refseq.end - refseq.start;
+                 if( stats._statsSampleFeatures >= 300 || interval * 2 > refLen || error ) {
                      console.log( 'Store statistics: '+(this.source||this.name), stats );
                      deferred.resolve( stats );
                  } else if( ((new Date()) - startTime) < timeout ) {

--- a/src/JBrowse/Store/SeqFeature/GlobalStatsEstimationMixin.js
+++ b/src/JBrowse/Store/SeqFeature/GlobalStatsEstimationMixin.js
@@ -7,9 +7,10 @@
 define([
            'dojo/_base/declare',
            'dojo/_base/array',
-           'dojo/Deferred'
+           'dojo/Deferred',
+           'JBrowse/Errors'
        ],
-       function( declare, array, Deferred ) {
+       function( declare, array, Deferred, Errors ) {
 
 return declare( null, {
 
@@ -22,6 +23,7 @@ return declare( null, {
         var deferred = new Deferred();
 
         refseq = refseq || this.refSeq;
+        var timeout = this.storeTimeout || 3000;
 
         var startTime = new Date();
 
@@ -43,20 +45,25 @@ return declare( null, {
                                                  });
                               },
                               function( error ) {
-                                      console.error( error );
                                       callback.call( thisB, length,  null, error );
                               });
         };
 
         var maybeRecordStats = function( interval, stats, error ) {
             if( error ) {
-                deferred.reject( error );
+                if(error.isInstanceOf(Errors.DataOverflow)) {
+                     console.log( 'Store statistics found chunkSizeLimit error, using empty: '+(this.source||this.name) );
+                     deferred.resolve( { featureDensity: 0, error: 'global stats estimation found chunkSizeError' } );
+                }
+                else {
+                    deferred.reject( error );
+                }
             } else {
                 var refLen = refseq.end - refseq.start;
-                 if( stats._statsSampleFeatures >= 300 || interval * 2 > refLen || error ) {
+                 if( stats._statsSampleFeatures >= 300 || error ) {
                      console.log( 'Store statistics: '+(this.source||this.name), stats );
                      deferred.resolve( stats );
-                 } else if( ((new Date()) - startTime) < 500 ) {
+                 } else if( ((new Date()) - startTime) < timeout ) {
                      statsFromInterval.call( this, interval * 2, maybeRecordStats );
                  } else {
                      console.log( 'Store statistics timed out: '+(this.source||this.name) );

--- a/src/JBrowse/Store/SeqFeature/VCFTabix.js
+++ b/src/JBrowse/Store/SeqFeature/VCFTabix.js
@@ -79,6 +79,8 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
                    },
                    lang.hitch( thisB, '_failAllDeferred' )
                  );
+
+        this.storeTimeout = args.storeTimeout || 3000;
     },
 
     /** fetch and parse the VCF header lines */


### PR DESCRIPTION
The stats estimation was given a timeout in #663 which is super, but it is also strict 500ms which leads to odd behavior such as that described in #727 

This PR adds two things

1) Configurable timeouts via a "storeTimeout" config variable. This timeout can be provided for a given track in their config, similar to how chunkSizeLimit can be modified in the config. The default for BAM, VCF, and BigWig is 3seconds. BigWig I think is important since autoscale global requires the global stats estimator to finish. The BAM is important since it causes behavior like #727 when it times out. Default for others is 500ms.

2) Handling the chunkSizeLimit error explicitly during stats estimation by replying with the same response as a timeout (i.e. just provide no statistics) which should fix #540 corner cases by allowing the track to be viewed instead of rejecting the track "completely" if it failed during stats estimation