### PR TITLE
XYPlot  - noFill option to give scatter like plots

### DIFF
--- a/src/JBrowse/View/Track/Wiggle/XYPlot.js
+++ b/src/JBrowse/View/Track/Wiggle/XYPlot.js
@@ -108,7 +108,11 @@ var XYPlot = declare( [WiggleBase, YScaleMixin],
                 if( score <= originY ) {
                     // bar goes upward
                     context.fillStyle = this.getConfForFeature('style.pos_color',f);
-                    thisB._fillRectMod( context, i, score, 1, originY-score+1);
+                    var height = originY-score+1;
+                    if(this.getConfForFeature('noFill', f) == true) {
+                      height = 1;
+                    }
+                    thisB._fillRectMod( context, i, score, 1, height);
                     if( !disableClipMarkers && score < 0 ) { // draw clip marker if necessary
                         context.fillStyle = this.getConfForFeature('style.clip_marker_color',f) || this.getConfForFeature('style.neg_color',f);
                         thisB._fillRectMod( context, i, 0, 1, 3 );
@@ -118,7 +122,13 @@ var XYPlot = declare( [WiggleBase, YScaleMixin],
                 else {
                     // bar goes downward
                     context.fillStyle = this.getConfForFeature('style.neg_color',f);
-                    thisB._fillRectMod( context, i, originY, 1, score-originY+1 );
+                    var top = originY;
+                    var height = score-originY;
+                    if(this.getConfForFeature('noFill', f) == true) {
+                      top = score-1;
+                      height = 1;
+                    }
+                    thisB._fillRectMod( context, i, top, 1,  height);
                     if( !disableClipMarkers && score >= canvasHeight ) { // draw clip marker if necessary
                         context.fillStyle = this.getConfForFeature('style.clip_marker_color',f) || this.getConfForFeature('style.pos_color',f);
                         thisB._fillRectMod( context, i, canvasHeight-3, 1, 3 );

--- a/src/JBrowse/View/Track/Wiggle/XYPlot.js
+++ b/src/JBrowse/View/Track/Wiggle/XYPlot.js
@@ -33,6 +33,27 @@ var XYPlot = declare( [WiggleBase, YScaleMixin],
         );
     },
 
+        _trackMenuOptions: function() {
+        var track = this;
+        var options = this.inherited(arguments) || [];
+
+        options.push({
+            label: 'No Fill',
+            type: 'dijit/CheckedMenuItem',
+            checked: !!(this.config.noFill == true),
+            onClick: function(event) {
+                if (this.checked) {
+                    track.config.noFill = true;
+                } else {
+                    track.config.noFill = false;
+                }
+                track.browser.publish('/jbrowse/v1/v/tracks/replace', [track.config]);
+            }
+        });
+
+        return options;
+    },
+
     _getScaling: function( viewArgs, successCallback, errorCallback ) {
 
         this._getScalingStats( viewArgs, dojo.hitch(this, function( stats ) {


### PR DESCRIPTION
As discussed in https://github.com/GMOD/jbrowse/issues/740

Adds 'noFill' option which results in just the top (or bottom) end of bar being rendered for XYplot.  Image shows 2 tracks, positive and negative values respectively (a mirror image of each other). 

<img width="301" alt="screen shot 2016-05-13 at 22 21 09" src="https://cloud.githubusercontent.com/assets/3740323/15262333/99da5324-1959-11e6-8a14-5a31604bc9b3.png">

Just need to add `"noFill": true` to track config, e.g. a base loaded BigWig track would now be:

```
{
  "maxExportSpan": 500000,
  "autoscale": "local",
  "logScaleOption": true,
  "style": {
    "pos_color": "blue",
    "neg_color": "red",
    "origin_color": "#888",
    "variance_band_color": "rgba(0,0,0,0.3)",
    "height": 100
  },
  "label": "BigWig_1kb_1",
  "key": "BigWig 1kb",
  "type": "JBrowse/View/Track/Wiggle/XYPlot",
  "category": "Local tracks",
  "metadata": {},
  "noFill": true
}
```
