### PR TITLE
Fix 'normal is not defined' error on Chrome 51

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "util":         "dojo/util#1.9.8",
     "put-selector": "0.3.6",
     "dgrid":        "0.3.17",
-    "xstyle":       "0.3.1",
+    "xstyle":       "0.3.2",
     "jDataView":    "rbuels/jDataView",
     "jszlib":       "rbuels/jszlib",
     "FileSaver":    "dkasenberg/FileSaver.js",


### PR DESCRIPTION
Chrome 51 has some behavior that creates an error that says "normal is not defined" on page load

This can prevent jbrowse from loading altogether

The root of the problem is described here https://github.com/kriszyp/xstyle/issues/56


We can fix by bumping xstyle version from 0.3.1->0.3.2
