### PR TITLE
Add fix for #567

### DIFF
--- a/src/JBrowse/GenomeView.js
+++ b/src/JBrowse/GenomeView.js
@@ -64,6 +64,7 @@ constructor: function( args ) {
     var stripeWidth = args.stripeWidth;
     var refseq = args.refSeq;
     var zoomLevel = args.zoomLevel;
+    this.trackMod = {};
 
     // keep a reference to the main browser object
     this.browser = browser;
@@ -1070,6 +1071,7 @@ setLocation: function(refseq, startbp, endbp) {
         endbp = refseq.end;
 
     function removeTrack( track ) {
+        delete thisB.trackMod[track.name];
         if (track.div && track.div.parentNode)
             track.div.parentNode.removeChild(track.div);
     };
@@ -2037,9 +2039,10 @@ showVisibleBlocks: function(updateHeight, pos, startX, endX) {
 showTracks: function( trackConfigs ) {
     // filter out any track configs that are already displayed
     var needed = dojo.filter( trackConfigs, function(conf) {
-        return this._getTracks( [conf.label] ).length == 0;
+        return this._getTracks( [conf.label] ).length == 0 && !this.trackMod[conf.label];
     },this);
     if( ! needed.length ) return;
+    array.forEach(trackConfigs, function(ret) { this.trackMod[ret.label] = true; }, this);
 
     // insert the track configs into the trackDndWidget ( the widget
     // will call create() on the confs to render them)
@@ -2102,6 +2105,7 @@ hideTracks: function( /**Array[String]*/ trackConfigs ) {
         return this._getTracks( [conf.label] ).length != 0;
     },this);
     if( ! displayed.length ) return;
+    array.forEach(trackConfigs, function(ret) { delete this.trackMod[ret.label]; }, this);
 
     // remove the track configs from the trackDndWidget ( the widget
     // will call create() on the confs to render them )


### PR DESCRIPTION
This is a proposed fix for #567 that addresses the issue by creating a new object to watch the opened tracks in parallel to the list of the actual track objects. The reason for making this new object is that fully initializing the regular track objects takes time at startup, so the main list of actual tracks doesn't get initialized in time for the duplication to be realized. Therefore if two different showTracks commands are entered with the same track, it can be duplicated.