### PR TITLE
Make the track labels not re-appear on scrolling

### DIFF
--- a/plugins/HideTrackLabels/js/main.js
+++ b/plugins/HideTrackLabels/js/main.js
@@ -100,13 +100,21 @@ return declare( JBrowsePlugin,
             dojo.attr(dom.byId("hidetitles-btn"),"disabled","");
             setTimeout(function(){
                 dojo.removeAttr(dom.byId("hidetitles-btn"),"disabled");
-            },1000);
+            }, 200);
 
+            if(direction==-1) {
+                setTimeout(function() {
+                    query('.track-label').style('visibility', 'hidden')
+                }, 200);
+            } else {
+                query('.track-label').style('visibility', 'visible')
+            }
             // slide em
             query(".track-label").forEach(function(node, index, arr){
                 var w = domGeom.getMarginBox(node).w;
                 coreFx.slideTo({
                   node: node,
+                  duration: 200,
                   top: domGeom.getMarginBox(node).t.toString(),
                   left: (domGeom.getMarginBox(node).l + (w*direction) ).toString(),
                   unit: "px"


### PR DESCRIPTION
This fixes the HideTrackLabels plugin to not re-show the track labels during scrolling

Follow up to comments made on this commit https://github.com/GMOD/jbrowse/commit/d4008c058854fb584edef9f344ca1a10599a876d




