### PR TITLE
Load comments track main stylesheet from index view

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <title>JBrowse</title>
     <link rel="stylesheet" type="text/css" href="css/genome.css">
     <link rel="stylesheet" type="text/css" href="plugins/CommentFeatures/css/sidebar.css">
+    <link rel="stylesheet" type="text/css" href="plugins/CommentFeatures/css/main.css">
     <script type="text/javascript">
             // jshint unused: false
             var dojoConfig = {


### PR DESCRIPTION
Since the partial work done in CommentsTrack plugin was removed from the repo to avoid the travis ci build fail, the main stylesheet needed by the Comments Track was added to the index.html file manually.