### PR TITLE
Adds `fullviewlink` URL param to enable/disable "Full-screen view" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
                        show_tracklist: queryParams.tracklist,
                        show_overview: queryParams.overview,
                        show_menu: queryParams.menu,
+                       show_fullviewlink: queryParams.fullviewlink,
                        show_tracklabels: queryParams.tracklabels,
                        highResolutionMode: queryParams.highres,
                        stores: { url: { type: "JBrowse/Store/SeqFeature/FromConfig", features: [] } },

--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -903,9 +903,10 @@ initView: function() {
             var snapLink = this.makeSnapLink();
             if(snapLink) { menuBar.appendChild( snapLink ); }
         }
-        else
+        else {
             if ( this.config.show_fullviewlink )
                 menuBar.appendChild( this.makeFullViewLink() );
+        }
 
 
         this.viewElem = document.createElement("div");

--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -904,7 +904,8 @@ initView: function() {
             if(snapLink) { menuBar.appendChild( snapLink ); }
         }
         else
-            menuBar.appendChild( this.makeFullViewLink() );
+            if ( this.config.show_fullviewlink )
+                menuBar.appendChild( this.makeFullViewLink() );
 
 
         this.viewElem = document.createElement("div");
@@ -1947,7 +1948,7 @@ loadConfig: function () {
                                this._addTrackConfigs( tracks );
 
                                // coerce some config keys to boolean
-                               dojo.forEach( ['show_tracklist','show_nav','show_overview','show_menu', 'show_tracklabels'], function(v) {
+                               dojo.forEach( ['show_tracklist','show_nav','show_overview','show_menu', 'show_fullviewlink', 'show_tracklabels'], function(v) {
                                                  this.config[v] = this._coerceBoolean( this.config[v] );
                                              },this);
 
@@ -2037,6 +2038,7 @@ _configDefaults: function() {
         show_nav: true,
         show_menu: true,
         show_overview: true,
+        show_fullviewlink: true,
 
         refSeqs: "{dataRoot}/seq/refSeqs.json",
         include: [


### PR DESCRIPTION
This PR makes available a new URL parameter named `fullviewlink`, used to control the visibility of the "Full-screen view" button/link.

This is potentially useful in situations where other parameters like `nav`, `overview`, `tracklist` are toggled _off_ (0) to generate an embeddable JBrowse view without any controls, suitable for taking screenshots.

Here is a working example instance on Araport.org, which shows this functionality: https://www.araport.org/locus/AT4G11330/browse?nav=0&overview=0&tracklist=0&fullviewlink=0

CC @keiranmraine 
