### PR TITLE
Fix for 'Error reading from name store'

### DIFF
--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -2303,7 +2303,9 @@ navigateTo: function(loc) {
                     className: 'notfound-dialog'
                 }).show();
             },
-            thisB.callLocation(loc));
+            function() {
+                thisB.callLocation(loc)
+            });
     });
 },
 

--- a/src/JBrowse/Store/Hash.js
+++ b/src/JBrowse/Store/Hash.js
@@ -60,7 +60,11 @@ return declare( null, {
             .then( function() {
                        var bucketIdent = thisB._hash( key );
                        return thisB.bucketStore
-                           .get( thisB._hexToDirPath( bucketIdent ) );
+                           .get( thisB._hexToDirPath( bucketIdent ) ).then( function(value) {
+                                return value;
+                            }, function(err) {
+                                return {};
+                            });
                    });
     },
 

--- a/src/JBrowse/Store/Hash.js
+++ b/src/JBrowse/Store/Hash.js
@@ -63,7 +63,10 @@ return declare( null, {
                            .get( thisB._hexToDirPath( bucketIdent ) ).then( function(value) {
                                 return value;
                             }, function(err) {
-                                return {};
+                                if (err.status == 404) {
+                                    // 404 is expected if the name is not in the store
+                                    return {};
+                                }
                             });
                    });
     },


### PR DESCRIPTION
Hi!
This is a fix for the error message 'Error reading from name store' I get when opening a JBrowse instance for the first time, or clicking on "Go" with random stuff in the search box.
I'm not sure if this is very elegant, or if it could have some side effect, but I thought it was worth opening the PR.
