### PR TITLE
Add list of plugins

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1077,3 +1077,17 @@ table.baseQuality td {
     display: block;
     text-align: center;
 }
+
+.about-dialog .loaded-plugins {
+    text-align: left;
+}
+
+.about-dialog .loaded-plugins li {
+    margin: 0em;
+}
+
+.about-dialog .plugins-list {
+    max-height: 100px;
+    overflow: auto;
+}
+

--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -1338,7 +1338,7 @@ browserMeta: function() {
             + '  <a class="mainsite" target="_blank" href="http://jbrowse.org">JBrowse website</a>'
             + '  <div class="gmod">JBrowse is a <a target="_blank" href="http://gmod.org">GMOD</a> project.</div>'
             + '  <div class="copyright">&copy; 2013 The Evolutionary Software Foundation</div>'
-            + (Object.keys(this.plugins).length>1 ? (
+            + ((Object.keys(this.plugins).length>1&&!this.config.noPluginsForAboutBox) ? (
                 '  <div class="loaded-plugins">Loaded plugins<ul class="plugins-list">'
                 + array.map(Object.keys(this.plugins), function(elt) {
                     var p = this.plugins[elt];

--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -1338,6 +1338,14 @@ browserMeta: function() {
             + '  <a class="mainsite" target="_blank" href="http://jbrowse.org">JBrowse website</a>'
             + '  <div class="gmod">JBrowse is a <a target="_blank" href="http://gmod.org">GMOD</a> project.</div>'
             + '  <div class="copyright">&copy; 2013 The Evolutionary Software Foundation</div>'
+            + (Object.keys(this.plugins).length>1 ? (
+                '  <div class="loaded-plugins">Loaded plugins<ul class="plugins-list">'
+                + array.map(Object.keys(this.plugins), function(elt) {
+                    var p = this.plugins[elt];
+                    return '<li>'+
+                        (p.url ? '<a href="'+p.url+'">': '') + p.name + (p.url ? '</a>':'') +
+                        (p.author ? ' ('+p.author+')' : '')+'</li>'; }, this).join('')
+                + '  </ul></div>' ) : '')
             + '</div>';
     }
     return about;


### PR DESCRIPTION
This allows storing a list of plugins in the About box. The list will scroll also if there are a ton of plugins.

It lists the name of the plugin, and can also add author and url if the plugin adds the "author" and "url" properties to it's main object (e.g. this.url = 'blah', this.author='blah' in plugin constructor)


xref https://github.com/GMOD/jbrowse/issues/768
