### PR TITLE
Potential fix for gmod/apollo#1498

### DIFF
--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -188,7 +188,7 @@ constructor: function(params) {
                                // In rare cases thisB.config.defaultTracks already contained an array that appeared to
                                // have been split in a previous invocation of this function. Thus, we only try and split
                                // it if it isn't already split.
-                               if (!value instanceof Array) {
+                               if (!thisB.config.defaultTracks instanceof Array) {
                                   tracksToShow = tracksToShow.concat(thisB.config.defaultTracks.split(","));
                                }
                            }

--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -184,7 +184,14 @@ constructor: function(params) {
                            //    if no URL param and no tracks cookie, then use defaultTracks
                            if (thisB.config.forceTracks)   { tracksToShow = tracksToShow.concat(thisB.config.forceTracks.split(",")); }
                            else if (thisB.cookie("tracks")) { tracksToShow = tracksToShow.concat(thisB.cookie("tracks").split(",")); }
-                           else if (thisB.config.defaultTracks) { tracksToShow = tracksToShow.concat(thisB.config.defaultTracks.split(",")); }
+                           else if (thisB.config.defaultTracks) {
+                               // In rare cases thisB.config.defaultTracks already contained an array that appeared to
+                               // have been split in a previous invocation of this function. Thus, we only try and split
+                               // it if it isn't already split.
+                               if (!value instanceof Array) {
+                                  tracksToShow = tracksToShow.concat(thisB.config.defaultTracks.split(","));
+                               }
+                           }
                            // currently, force "DNA" _only_ if no other guides as to what to show?
                            //    or should this be changed to always force DNA to show?
                            if (tracksToShow.length == 0) { tracksToShow.push("DNA"); }
@@ -1690,17 +1697,17 @@ getStore: function( storeName, callback ) {
                              });
 
                  var store = new storeClass( storeArgs );
-                 
+
                  var cache = typeof storeArgs.storeCache==='undefined' || storeArgs.storeCache !== false;
-                 
+
                  if (cache)
                     this._storeCache[ storeName ] = { refCount: 1, store: store };
-                 
+
                  callback( store );
                  // release the callback because apparently require
                  // doesn't release this function
                  callback = undefined;
-                 
+
                  //if (cache)
                  //    delete store;
              }));


### PR DESCRIPTION
In some cases in  Apollo this variable was already an array causing breakages when the code called split. This *should* fix this issue.

This should not have a negative effect on the code otherwise.

Apologies for the unrelated deletions of trailing whitespace. I can re-commit without those if need be.