### PR TITLE
Add cacheMismatches option which greatly speeds up long reads processing

### DIFF
--- a/src/JBrowse/Store/SeqFeature/_MismatchesMixin.js
+++ b/src/JBrowse/Store/SeqFeature/_MismatchesMixin.js
@@ -28,6 +28,9 @@ return declare( null, {
 
     _getMismatches: function( feature ) {
         var mismatches = [];
+        if( this.config.cacheMismatches && feature.mismatches ) {
+            return feature.mismatches;
+        }
 
         // parse the CIGAR tag if it has one
         var cigarString = feature.get( this.cigarAttributeName ),
@@ -51,6 +54,9 @@ return declare( null, {
             seen[key] = true;
             return !s;
         });
+        if( this.config.cacheMismatches ) {
+            feature.mismatches = mismatches;
+        }
 
         return mismatches;
     },


### PR DESCRIPTION
The "advent" of long reads is upon us.... and you can try out open datasets like https://github.com/nickloman/massive-nanopore-silliness !

The fasta file NC_000913.fna and bam file gt350kb.split.sorted.bam are pretty good test files in that repo.

If added to jbrowse, an alignments2 track for example will work, but it is slow to scroll around. That seems to be because the mismatches are recalculated every time the read is rendered (and of course, mismatches are numerous over 50kb of read length), so this PR adds the ability to "cache" the mismatches on the feature object and this makes scrolling around faster.