### PR TITLE
Allow flexible parsing of the list of plugin types

### DIFF
--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -269,7 +269,7 @@ initPlugins: function() {
             plugins = function() {
                 var newplugins = [];
                 for( var pname in plugins ) {
-                    if( !( 'name' in plugins[pname] ) ) {
+                    if( lang.isObject(plugins[pname]) && !( 'name' in plugins[pname] ) ) {
                         plugins[pname].name = pname;
                     }
                     newplugins.push( plugins[pname] );


### PR DESCRIPTION
If you have in jbrowse.conf something like

    [plugins.DebugEvents]
    location = plugins/DebugEvents

And in trackList.json

    "plugins": ["NeatCanvasFeatures"]

Then this causes an error because one is the simple "name" type and the other has the "location" type. This is a simple fix for that