### PR TITLE
Adds config option `inferCdsParts` to ProcessedTranscript glyph

### DIFF
--- a/src/JBrowse/View/FeatureGlyph/ProcessedTranscript.js
+++ b/src/JBrowse/View/FeatureGlyph/ProcessedTranscript.js
@@ -102,8 +102,8 @@ _makeCDSs: function( parent, subparts ) {
     var codePartStart =  Infinity,
           codePartEnd = -Infinity;
     for ( i = 0; i < exons.length; i++ ) {
-        start = exons[i].get('start');
-        end = exons[i].get('end');
+        var start = exons[i].get('start');
+        var end = exons[i].get('end');
 
         // CDS containing exon
         if( codeStart >= start && codeEnd <= end ) {

--- a/src/JBrowse/View/FeatureGlyph/ProcessedTranscript.js
+++ b/src/JBrowse/View/FeatureGlyph/ProcessedTranscript.js
@@ -30,13 +30,18 @@ _defaultConfig: function() {
 
             subParts: 'CDS, UTR, five_prime_UTR, three_prime_UTR',
 
-            impliedUTRs: false
+            impliedUTRs: false,
+
+            inferCdsParts: false
         });
 },
 
 _getSubparts: function( f ) {
     var c = f.children();
     if( ! c ) return [];
+
+    if( c && this.config.inferCdsParts )
+        c = this._makeCDSs( f, c );
 
     if( c && this.config.impliedUTRs )
         c = this._makeUTRs( f, c );
@@ -47,6 +52,97 @@ _getSubparts: function( f ) {
             filtered.push( c[i] );
 
     return filtered;
+},
+
+_makeCDSs: function( parent, subparts ) {
+    // infer CDS parts from exon coordinates
+
+    var codeStart =  Infinity,
+          codeEnd = -Infinity;
+
+    var i;
+
+    // gather exons, find coding start and end
+    var type, codeIndices = [], exons = [];
+    for( i = 0; i < subparts.length; i++ ) {
+        type = subparts[i].get('type');
+        if( /^cds/i.test( type ) ) {
+            // if any CDSs parts are present already,
+            // bail and return all subparts as-is
+            if( /:CDS:/i.test( subparts[i].get('name') ) )
+                return subparts;
+
+            codeIndices.push(i);
+            if( codeStart > subparts[i].get('start') )
+                codeStart = subparts[i].get('start');
+            if( codeEnd < subparts[i].get('end') )
+                codeEnd = subparts[i].get('end');
+        }
+        else {
+            if( /exon/i.test( type ) ) {
+                exons.push( subparts[i] );
+            }
+        }
+    }
+
+    // splice out unspliced cds parts
+    codeIndices.sort( function(a,b) { return b - a; } );
+    for ( i = codeIndices.length - 1; i >= 0; i-- )
+        subparts.splice(codeIndices[i], 1);
+
+    // bail if we don't have exons and cds
+    if( !( exons.length && codeStart < Infinity && codeEnd > -Infinity ) )
+        return subparts;
+
+    // make sure the exons are sorted by coord
+    exons.sort( function(a,b) { return a.get('start') - b.get('start'); } );
+
+    // iterate thru exons again, and calculate cds parts
+    var strand = parent.get('strand');
+    var codePartStart =  Infinity,
+          codePartEnd = -Infinity;
+    for ( i = 0; i < exons.length; i++ ) {
+        start = exons[i].get('start');
+        end = exons[i].get('end');
+
+        // CDS containing exon
+        if( codeStart >= start && codeEnd <= end ) {
+            codePartStart = codeStart;
+            codePartEnd = codeEnd;
+        }
+        // 5' terminal CDS part
+        else if( codeStart >= start && codeStart < end ) {
+            codePartStart = codeStart;
+            codePartEnd = end;
+        }
+        // 3' terminal CDS part
+        else if( codeEnd > start && codeEnd <= end ) {
+            codePartStart = start;
+            codePartEnd = codeEnd;
+        }
+        // internal CDS part
+        else if( start < codeEnd && end > codeStart ) {
+            codePartStart = start;
+            codePartEnd = end;
+        }
+
+        // "splice in" the calculated cds part into subparts
+        // at beginning of _makeCDSs() method, bail if cds subparts are encountered
+        subparts.splice(i, 0, ( new SimpleFeature(
+                    {   parent: parent,
+                        data: {
+                            start: codePartStart,
+                            end: codePartEnd,
+                            strand: strand,
+                            type: 'CDS',
+                            name: parent.get('uniqueID') + ":CDS:" + i
+                        }})));
+    }
+
+    // make sure the subparts are sorted by coord
+    subparts.sort( function(a,b) { return a.get('start') - b.get('start'); } );
+
+    return subparts;
 },
 
 _makeUTRs: function( parent, subparts ) {


### PR DESCRIPTION
Assumes that JSON data for any particular gene feature being processed by JBrowse contains one complete CDS instead of disjointed features. The code in this PR makes use of the exon coordinates and total CDS span to infer the CDS parts.

Set `"inferCdsParts": true` in the track config to invoke this functionality.

This PR is being added to satisfy a specific use case, where JBrowse-compatible JSON data produced by the InterMine JBrowse REST API represents the CDS feature as a single element, mainly because of the way in which CDSs are loaded into the warehouse.

JBrowse installed at jbrowse.org without this fix: https://jbrowse.org/code/latest-release/?data=https://apps.araport.org/thalemine/service/jbrowse/config/3702&loc=Chr1:22311..32037&tracks=ThaleMine-3702-Gene&tracklist=0&nav=0&overview=0

JBrowse installed at Araport with this fix: https://apps.araport.org/jbrowse?data=https://apps.araport.org/thalemine/service/jbrowse/config/3702&loc=Chr1:22311..32037&tracks=ThaleMine-3702-Gene&tracklist=0&nav=0&overview=0&fullviewlink=0