### PR TITLE
Make superclean use -fdx to delete node_modules, extlib, etc

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -78,7 +78,7 @@ release-normal-test: release-normal
 	rm -rf $(RELEASE_FULL_DIR);
 	$(UNZIP) $(RELEASE_FULL).zip
 	cd $(RELEASE_FULL_DIR) \
-	  && ./setup.sh \
+	  && ./setup.sh legacy \
 	  && prove -Isrc/perl5 -r -j3 tests/perl_tests;
 
 
@@ -143,7 +143,7 @@ release-min-test: release-min
 	$(UNZIP) $(RELEASE_MIN).zip
 	rm $(RELEASE_MIN_DIR)/sample_data/raw/volvox
 	cp -R docs tests* sample_data $(RELEASE_MIN_DIR);
-	cd $(RELEASE_MIN_DIR) && ./setup.sh
+	cd $(RELEASE_MIN_DIR) && ./setup.sh legacy
 	cd $(RELEASE_MIN_DIR) && prove -Isrc/perl5 -r -j3 tests/perl_tests;
 
 bin/wig2png: src/wig2png/Makefile

--- a/build/Makefile
+++ b/build/Makefile
@@ -154,7 +154,7 @@ src/wig2png/configure: src/wig2png/configure.in
 	cd src/wig2png && autoconf
 
 superclean: clean
-	-git clean -fd --exclude=plugins/ \
+	-git clean -fdx --exclude=plugins/ \
 	    --exclude src/FileSaver/ \
 	    --exclude src/dbind/ \
 	    --exclude src/dgrid/ \


### PR DESCRIPTION
This changes the build slightly to use -fdx instead of -fd during release build

Note that it already used to do -fdx for makefile `superclean` target but after bower was implemented it switched to -fd with --excludes, but I think it's valid to change to -fdx with excludes

The effect of not having -fdx was visible in the 1.12.3rc1 where, for example, node_modules and extlib folders were included, when they can be omitted
