### PR TITLE
Fixes hierarchy of additional relative to core

### DIFF
--- a/src/JBrowse/View/Track/_FeatureDetailMixin.js
+++ b/src/JBrowse/View/Track/_FeatureDetailMixin.js
@@ -133,7 +133,7 @@ return declare( FeatureDescriptionMixin, {
                 },
                 container );
             array.forEach( additionalTags.sort(), function(t) {
-                this.renderDetailField( container, t, f.get(t), f );
+                this.renderDetailField( atElement, t, f.get(t), f );
             }, this );
         }
     },


### PR DESCRIPTION
I believe this is what was intended. Before this commit, all of .additional's children (other than the h2) were at the same level. This PR moves them into the container. 

![utvalg_005](https://cloud.githubusercontent.com/assets/458683/25116294/5b6bc8fe-23fb-11e7-9da7-9e7a9cddbdd4.png)