### PR TITLE
Allow adding arbitrary config to refseq block

### DIFF
--- a/bin/prepare-refseqs.pl
+++ b/bin/prepare-refseqs.pl
@@ -114,6 +114,12 @@ The displayed name of the sequence track, defaults to 'Reference sequence'.
 The Name of the alphabet used for these reference sequences, usually
 either 'dna', 'rna', or 'protein'.
 
+=item --trackConfig '{ JSON-format extra configuration for this track }'
+
+Additional top-level configuration for the client, in JSON syntax.  Example:
+
+  --trackConfig '{ "glyph": "ProcessedTranscript" }'
+
 =back
 
 =head1 AUTHOR

--- a/src/perl5/Bio/JBrowse/Cmd/FormatSequences.pm
+++ b/src/perl5/Bio/JBrowse/Cmd/FormatSequences.pm
@@ -44,6 +44,7 @@ sub option_definitions {(
     "trackLabel=s",
     "seqType=s",
     "key=s",
+    "config=s",
     "help|h|?",
     "nohash"
 )}
@@ -62,6 +63,12 @@ sub run {
         my $chunkSize = $self->opt('chunksize');
         $chunkSize *= 4 if $compress;
         $self->{chunkSize} = $chunkSize;
+    }
+
+    for my $optname ( qw( config ) ) {
+        if( my $o = $self->opt($optname) ) {
+            $self->opt( $optname => Bio::JBrowse::JSON->new->decode( $o ));
+        }
     }
 
     my $refs = $self->opt('refs');
@@ -404,6 +411,7 @@ sub writeTrackEntry {
                                                ( 'dna' eq lc $self->opt('seqType') ? () : ('showReverseStrand' => 0 ) ),
                                                ( 'protein' eq lc $self->opt('seqType') ? ('showTranslation' => 0) : () ),
                                                ( defined $self->opt('seqType') ? ('seqType' => lc $self->opt('seqType')) : () ),
+                                               %{ $self->opt('config') || {} },
                                            };
                                            if ( $self->opt('indexed_fasta') ) {
                                                $tracks->[$i]->{'storeClass'} = 'JBrowse/Store/Sequence/IndexedFasta';

--- a/src/perl5/Bio/JBrowse/Cmd/FormatSequences.pm
+++ b/src/perl5/Bio/JBrowse/Cmd/FormatSequences.pm
@@ -44,7 +44,7 @@ sub option_definitions {(
     "trackLabel=s",
     "seqType=s",
     "key=s",
-    "config=s",
+    "trackConfig=s",
     "help|h|?",
     "nohash"
 )}
@@ -65,7 +65,8 @@ sub run {
         $self->{chunkSize} = $chunkSize;
     }
 
-    for my $optname ( qw( config ) ) {
+    # If trackConfig is supplied, decode as JSON
+    for my $optname ( qw( trackConfig ) ) {
         if( my $o = $self->opt($optname) ) {
             $self->opt( $optname => Bio::JBrowse::JSON->new->decode( $o ));
         }
@@ -411,7 +412,8 @@ sub writeTrackEntry {
                                                ( 'dna' eq lc $self->opt('seqType') ? () : ('showReverseStrand' => 0 ) ),
                                                ( 'protein' eq lc $self->opt('seqType') ? ('showTranslation' => 0) : () ),
                                                ( defined $self->opt('seqType') ? ('seqType' => lc $self->opt('seqType')) : () ),
-                                               %{ $self->opt('config') || {} },
+                                               # Merge in any extra trackConfig supplied by the user.
+                                               %{ $self->opt('trackConfig') || {} },
                                            };
                                            if ( $self->opt('indexed_fasta') ) {
                                                $tracks->[$i]->{'storeClass'} = 'JBrowse/Store/Sequence/IndexedFasta';


### PR DESCRIPTION
Just like `bin/flatfile-to-json.pl`, this change enables a `--config` flag on `prepare-refseqs.pl` which allows adding arbitrary JSON to the refseq when it is added.

This is needed because I've started adding the `metadata` blocks for faceted track selector and as part of a completely automated pipeline. My tool that's building the trackList.json needs to be adding metadata to the right reference sequence, and I don't want to have to look through and guess which refseq track it is supposed to be.