### PR TITLE
Update so that setup.sh does not try to run bower when pre-compiled

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -70,9 +70,6 @@ elif ! [ -f "src/dojo/dojo.js" ]; then
     echo "Dojo does not exist, installing" ;
     check_bower >> setup.log ;
     $bower_executable install -f --allow-root >> setup.log ;
-else
-    check_bower >> setup.log ;
-    echo -n "  Bower dependencies already installed.  Type '$bower_executable install -f --allow-root' to force reinstallation of dependencies.";
 fi
 echo "done"
 


### PR DESCRIPTION
I think the check_bower command should be removed when jbrowse is pre-compiled (as in the 1.12.3 release) because otherwise it prints a ton of warnings and permission denied errors )ref #873).

I think the message about "reinstalling" dependencies is probably unneeded too, it doesn't seem like something I'd recommend a user do 
