### PR TITLE
Disable CORS header on refSeqs.json request

### DIFF
--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -527,7 +527,12 @@ loadRefSeqs: function() {
             this.addRefseqs( this.config.refSeqs.data );
             deferred.resolve({success:true});
         } else {
-            request(this.config.refSeqs.url, { handleAs: 'text' } )
+            request(this.config.refSeqs.url, {
+                handleAs: 'text',
+                headers: {
+                    'X-Requested-With': null 
+                }
+            } )
                 .then( function(o) {
                            thisB.addRefseqs( dojo.fromJson(o) );
                            deferred.resolve({success:true});

--- a/src/JBrowse/Store/NCList.js
+++ b/src/JBrowse/Store/NCList.js
@@ -163,8 +163,12 @@ NCList.prototype.iterHelper = function(arr, from, to, fun,
                                 /\{Chunk\}/ig, chunkNum
                         )
                     ),
-                    { handleAs: 'json' }
-                ).then(
+                    {
+                        handleAs: 'json',
+                        headers: {
+                            'X-Requested-With': null 
+                    }
+                }).then(
                     function( sublist ) {
                         return thisB.iterHelper(
                             sublist, from, to, fun,

--- a/src/JBrowse/Store/NCList_v0.js
+++ b/src/JBrowse/Store/NCList_v0.js
@@ -134,6 +134,9 @@ NCList_v0.prototype.iterHelper = function(arr, from, to, fun, finish,
                                    arr[i][this.lazyIndex].chunk
                                 )
                              ),
+                        headers: {
+                            'X-Requested-With': null 
+                        },
                         handleAs: "json",
                         load: function(lazyFeat, lazyObj,
                                        sublistIndex, parentIndex) {

--- a/src/JBrowse/Store/SeqFeature/NCList.js
+++ b/src/JBrowse/Store/SeqFeature/NCList.js
@@ -78,7 +78,13 @@ return declare( SeqFeatureStore,
 
             // fetch the trackdata
             var thisB = this;
-            xhr.get( url, { handleAs: 'json', failOk: true })
+            xhr.get( url, {
+                handleAs: 'json',
+                failOk: true,
+                headers: {
+                    'X-Requested-With': null 
+                }
+            })
                .then( function( trackInfo, request ) {
                           //trackInfo = JSON.parse( trackInfo );
                           thisB._handleTrackInfo( refData, trackInfo, url );


### PR DESCRIPTION
This follows up on this PR https://github.com/GMOD/jbrowse/pull/839 to allow more cross-origin support. Example


http://jbrowse.org/code/JBrowse-1.12.3/?data=https%3A%2F%2Fcdn.rawgit.com%2Fgmod%2Fjbrowse-registry%2F227c645c%2Fdemos%2Fgwasviewer&loc=16%3A36137482..54208432&tracks=&highlight=

This link currently doesn't work but would succeed after this applying this change (can try out the same url locally on your computer)