### PR TITLE
Add bower config files back

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "src"
+}

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "jbrowse",
+  "version": "1.12.2-SNAPSHOT",
+  "dependencies": {
+    "dojo":         "1.12.2",
+    "dojox":        "1.12.2",
+    "dijit":        "1.12.2",
+    "util":         "dojo/util#1.12.2",
+    "dgrid":        "1.1.0",
+    "dstore":       "1.1.1",
+    "jDataView":    "rbuels/jDataView",
+    "jszlib":       "rbuels/jszlib",
+    "FileSaver":    "dkasenberg/FileSaver.js",
+    "json-schema":  "kriszyp/json-schema#0.2.1",
+    "lazyload":     "rbuels/lazyload#amd",
+    "dbind":        "rbuels/dbind"
+  }
+}


### PR DESCRIPTION
This is a PR follow up to #906 to restore bower config files

It was mentioned that bower can still be useful in installing dependencies in test datasets


In the plugin context it was sort of interesting because it could fit into a workflow that included jbrowse as a "package" see http://searchvoidstar.tumblr.com/post/143063018578/creating-a-testing-framework-for-jbrowse-plugins


In #906 it was mentioned that the npm doesn't yet have the ability to install itself as a package so retaining bower until this is done could be useful