### PR TITLE
make refSeqOrder customisable

### DIFF
--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -2182,14 +2182,19 @@ addRefseqs: function( refSeqs ) {
             }
             else {
                 order = refSeqs.slice(0);
+                if ( ['length', 'name', 'length ascending', 'name descending'].indexOf(this.config.refSeqOrder) === -1 ) {
+                    __refSeqOrder = this.config.refSeqOrder.split(/\s*,\s*/);
+                }
                 order.sort(
                     this.config.refSeqOrder == 'length' || this.config.refSeqOrder == 'length ascending'
                                                                    ? function( a, b ) { return a.length - b.length;  }  :
                     this.config.refSeqOrder == 'length descending' ? function( a, b ) { return b.length - a.length;  }  :
                     this.config.refSeqOrder == 'name descending'   ? function( a, b ) { return b.name.localeCompare( a.name ); } :
-                                                                     function( a, b ) { return a.name.localeCompare( b.name ); }
+                    this.config.refSeqOrder == 'name'              ? function( a, b ) { return a.name.localeCompare( b.name ); } :
+                                                                     function( a, b ) { return __refSeqOrder.indexOf( a.name ) > __refSeqOrder.indexOf( b.name ); }
                 );
             }
+
             return array.map( order, function( r ) {
                                   return r.name;
                               });


### PR DESCRIPTION
Here is a solution of mime, ref: #919 

In the config file, the `refSeqOrder` can be set as string of seq names that separated by comma

For example:

```
[ general]
refSeqOrder = ctgB,ctgA
```