### PR TITLE
Add option to hide unspliced reads for BAM tracks

### DIFF
--- a/src/JBrowse/View/Track/Alignments.js
+++ b/src/JBrowse/View/Track/Alignments.js
@@ -33,6 +33,7 @@ return declare( [ HTMLFeatures, AlignmentsMixin],
                 hideSupplementary: true,
                 hideMissingMatepairs: false,
                 hideUnmapped: true,
+                hideUnsplicedReads: false,
                 hideForwardStrand: false,
                 hideReverseStrand: false,
 

--- a/src/JBrowse/View/Track/Alignments2.js
+++ b/src/JBrowse/View/Track/Alignments2.js
@@ -30,6 +30,7 @@ return declare( [ CanvasFeatureTrack, AlignmentsMixin ], {
                 hideSecondary: true,
                 hideSupplementary: true,
                 hideUnmapped: true,
+                hideUnsplicedReads: false,
                 hideMissingMatepairs: false,
                 hideForwardStrand: false,
                 hideReverseStrand: false,

--- a/src/JBrowse/View/Track/_AlignmentsMixin.js
+++ b/src/JBrowse/View/Track/_AlignmentsMixin.js
@@ -192,6 +192,12 @@ return declare([ MismatchesMixin, NamedFeatureFiltersMixin ], {
                     func: function( f ) {
                         return f.get('strand') != -1;
                     }
+                },
+                hideUnsplicedReads: {
+                    desc: 'Hide unspliced reads',
+                    func: function ( f ) {
+                        return f.get('cigar').indexOf("N") != -1;
+                    }
                 }
             });
     },
@@ -211,7 +217,8 @@ return declare([ MismatchesMixin, NamedFeatureFiltersMixin ], {
                                'hideUnmapped',
                                'SEPARATOR',
                                'hideForwardStrand',
-                               'hideReverseStrand'
+                               'hideReverseStrand',
+                               'hideUnsplicedReads'
                            ],
                            filters );
                    });


### PR DESCRIPTION
@enuggetry @nathandunn @cmdcolin 

There was a request for adding the ability to hide unspliced reads while viewing RNAseq alignment BAMs. 

This PR aims at providing an option to hide reads that are not spliced, inferred from the cigar string of a read.

