### PR TITLE
A minor fix for _getFeatures in BAM store

### DIFF
--- a/src/JBrowse/Store/SeqFeature/BAM.js
+++ b/src/JBrowse/Store/SeqFeature/BAM.js
@@ -107,7 +107,7 @@ var BAMStore = declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesM
 
     // called by getFeatures from the DeferredFeaturesMixin
     _getFeatures: function( query, featCallback, endCallback, errorCallback ) {
-        this.bam.fetch( this.refSeq.name, query.start, query.end, featCallback, endCallback, errorCallback );
+        this.bam.fetch( query.ref, query.start, query.end, featCallback, endCallback, errorCallback );
     },
 
     saveStore: function() {

--- a/src/JBrowse/Store/SeqFeature/BAM.js
+++ b/src/JBrowse/Store/SeqFeature/BAM.js
@@ -107,7 +107,7 @@ var BAMStore = declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesM
 
     // called by getFeatures from the DeferredFeaturesMixin
     _getFeatures: function( query, featCallback, endCallback, errorCallback ) {
-        this.bam.fetch( query.ref, query.start, query.end, featCallback, endCallback, errorCallback );
+        this.bam.fetch( query.ref ? query.ref : this.refSeq.name, query.start, query.end, featCallback, endCallback, errorCallback );
     },
 
     saveStore: function() {


### PR DESCRIPTION
Currently the _getFeatures function in JBrowse/Store/SeqFeature/BAM uses `this.refSeq.name` to get the sequence name instead of getting the sequence name from the `query` argument.

While this works for JBrowse, it can be difficult if the `query` contains a sequence name which is different from `this.refSeq.name`.

This PR aims at fixing this minor detail.

@nathandunn @enuggetry 
