### PR TITLE
Add config option - no obscure track labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 dist: trusty
-language: node_js
-node_js:
-    - "8"
+language: perl
 addons:
   apt:
     packages:
@@ -16,7 +14,6 @@ before_install:
   - cpanm --notest GD::Image Text::Markdown DateTime
   - cpanm --notest git://github.com/bioperl/bioperl-live.git@v1.6.x
   - npm install -g jshint
-  - perl -v
 install:
   - npm install
   - bash setup.sh legacy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 sudo: false
 dist: trusty
-language: perl
+language: node_js
 node_js:
     - "8"
-    - "7"
-    - "6"
-    - "5"
 addons:
   apt:
     packages:
@@ -19,6 +16,7 @@ before_install:
   - cpanm --notest GD::Image Text::Markdown DateTime
   - cpanm --notest git://github.com/bioperl/bioperl-live.git@v1.6.x
   - npm install -g jshint
+  - perl -v
 install:
   - npm install
   - bash setup.sh legacy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 dist: trusty
-language: node_js
+language: perl
 node_js:
     - "8"
     - "7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: false
 dist: trusty
-language: perl
+language: node_js
+node_js:
+    - "8"
+    - "7"
+    - "6"
+    - "5"
 addons:
   apt:
     packages:

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,5 +1,18 @@
 {{$NEXT}}
 
+## Minor improvements
+  * Added trackLabels: "no-block" config feature.  Moves track labels/menus 
+    above the features so as not to obscure the features. (issue #901, #490)
+
+  * Make jbrowse npm installable. thanks to @cmdcolin & @enuggetry.
+
+  * implement express server for jbrowse for quick launch (jb_run.js).  @enuggetry.
+
+  * jb_setup.js @enuggetry.
+
+  ...
+
+
 # Release 1.12.3     2017-05-02 19:20:01 America/Los_Angeles
 
 ## Minor improvements

--- a/src/JBrowse/GenomeView.js
+++ b/src/JBrowse/GenomeView.js
@@ -59,12 +59,13 @@ var locationThumbMover = declare( dndMove.constrainedMoveable, {
 return declare( [Component,FeatureFiltererMixin], {
 
 constructor: function( args ) {
+    console.log(">>> view constructor");
     var browser = args.browser;
     var elem = args.elem;
     var stripeWidth = args.stripeWidth;
     var refseq = args.refSeq;
     var zoomLevel = args.zoomLevel;
-
+    
     // keep a reference to the main browser object
     this.browser = browser;
     this.setFeatureFilterParentComponent( this.browser );
@@ -78,6 +79,12 @@ constructor: function( args ) {
     // Add an arbitrary 50% padding between the position labels and the
     // topmost track
     this.topSpace = this.posHeight*1.5;
+
+    // handle trackLabels option
+    if (typeof browser.config.trackLabels !== 'undefined' && browser.config.trackLabels === "no-block") {
+        this.trackPadding = 35;
+        this.topSpace = this.posHeight*3;
+    }
 
     // WebApollo needs max zoom level to be sequence residues char width
     this.maxPxPerBp = this.config.maxPxPerBp;

--- a/src/JBrowse/View/Track/BlockBased.js
+++ b/src/JBrowse/View/Track/BlockBased.js
@@ -170,14 +170,21 @@ return declare( [Component,DetailsMixin,FeatureFiltererMixin,Destroyable],
     },
 
     makeTrackLabel: function() {
-        var labelDiv = dojo.create(
-            'div', {
+        
+        var params = {
                 className: "track-label dojoDndHandle",
                 id: "label_" + this.name,
                 style: {
                     position: 'absolute'
                 }
-            },this.div);
+            };
+        
+        if (typeof this.browser.config.trackLabels !== 'undefined' && this.browser.config.trackLabels==='no-block') {
+            params.style.top = "-30px";
+        }
+        
+        var labelDiv = dojo.create(
+            'div', params ,this.div);
 
         this.label = labelDiv;
 


### PR DESCRIPTION
Add config feature to move track labels/menus above the features so as not to obscure the features. Adds a little more spacing between tracks and between the first track and the genome view. Activated with trackLabels: "no-block" in trackList.json.