### PR TITLE
Make the trackPadding attribute use config for issue #901

### DIFF
--- a/src/JBrowse/GenomeView.js
+++ b/src/JBrowse/GenomeView.js
@@ -82,7 +82,7 @@ constructor: function( args ) {
 
     // handle trackLabels option
     if (typeof browser.config.trackLabels !== 'undefined' && browser.config.trackLabels === "no-block") {
-        this.trackPadding = 35;
+        this.config.trackPadding = 35;
         this.topSpace = this.posHeight*3;
     }
 


### PR DESCRIPTION
I think one of the code changes for issue #901 might have intended to use the config variable trackPadding in this way, so this is just a one line PR



Can see in screenshots


Before (has small amount of tracklabel overhanging previous track):

![screenshot-localhost-8000-2017-10-30-22-29-56-467](https://user-images.githubusercontent.com/6511937/32239520-25110a4a-be41-11e7-9f63-05d318c6d635.png)


After:

![screenshot-localhost-8000-2017-10-30-22-29-05-258](https://user-images.githubusercontent.com/6511937/32239532-2aa3a3dc-be41-11e7-9ac6-b9f31c358052.png)

