### PR TITLE
Break release notes into bug fixes and improvements

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -2,9 +2,16 @@
 
 ## Minor improvements
 
-  * Fixed SEVERE performance regression that basically made flatfile-to-json.pl
-    unusable on Perl 5.18 and higher. Huge thanks to Colin Diesh for tracking
-    this down. (issue #470, pull #912, @cmdcolin)
+  * Changed the project's `git` workflow to utilize a `dev` branch that is separate from
+    `master`, with `master` only being updated when a new release of JBrowse is published.
+    (issue #975, @enuggetry)
+
+  * Implemented npm install of JBrowse and added automated deployment of JBrowse releases to
+    GitHub releases and `npm`. Thanks to @abretaud, @nathandunn, @erasche, and @cmdcolin for
+    valuable discussions. (issue #822, pull #979, pull #984, @rbuels)
+
+  * Implemented a built-in node.js Express server `jb_run.js` for quick JBrowse launching.
+    @enuggetry
 
   * Added code to calculate feature density histograms for Tabix-indexed GFF3
     (`GFF3Tabix`) data sources. Thanks to @nathandunn for noticing and fixing
@@ -15,48 +22,77 @@
     Thanks to Deepak Kunni and Nathan Dunn for their work on this.
     (pull #921, @deepakunni3)
 
-  * setup.sh now uses npm instead of Bower (which is deprecated) to install
-    dependencies. @enuggetry
+  * Added trackLabels: "no-block" config feature.  Moves track labels/menus
+    above the features so as not to obscure the features. (issue #901, #490)
+
+  * Allows for dot-notation instead of JSON (pull #952) for addTracks, addBookmarks,
+    addFeatures, and addStores. Addresses security concerns running under Tomcat (pull
+    #952, @nathandunn).
+
+  * If a track has no `key` set in its track configuration, JBrowse will now look for
+    a `key` in its track metadata, and use that if it is present. Thanks to Loraine
+    Guéguen for the idea (issue #957, pull #958). @rbuels
+
+  * Added a configuration option that can disable JBrowse's behavior of updating the
+    browser's title text as the view changes. Thanks to Luka Jeran, Primož Hadalin,
+    and Nathan Dunn for this! (pull #904, @lukaw3d)
+
+  * Upgraded to use new Google Analytics API for usage reporting. (pull #917, @rdhayes)
+
+  * Made a cosmetic change to Alignments track detail popups, changing "Length on ref" to
+    be displayed as "Seq length on ref", so that it is displayed more usefully next to
+    "Seq length".  Thanks to @colindaven for the suggestion and implementation!
+    (pull #939, @colindaven)
+
+  * Improved the error messages displayed when a JBrowse glyphs, tracks, and plugins fail
+    to load. Thanks to @scottcain and @cmdcolin for tracking down the issue and improving
+    the error handling! (issue #968, @cmdcolin)
+
+  * Improved documentation of the `CategoryURL` plugin. (pull #985, @enuggetry)
+
+  * Re-enabled and improved documentation and configurability of the gradient colors in the
+    `NeatCanvasFeatures` plugin. (issue #982, pull #985, @enuggetry)
 
   * Removed legacy `wig-to-json.pl` and `bam-to-json.pl` scripts.  @rbuels
 
   * Added a `--trackConfig` option to `prepare-refseqs.pl` to allow injecting
     refseq configuration variables at format time. (pull #884, @erasche)
 
-  * Added trackLabels: "no-block" config feature.  Moves track labels/menus
-    above the features so as not to obscure the features. (issue #901, #490)
+  * Added an `--unsorted` option to `prepare-refseqs.pl` that formats reference sequences
+    in the same order in which they appear in the input sequence file.  Thanks to
+    @dsenalik for the suggestion and implementation! (pull #924, @dsenalik)
+
+  * Add `--config` command-line option to `add-bw-track.pl` and `add-bam-track.pl`
+    scripts. Thanks to Chris Childers for suggesting this! (issue #620, @rbuels)
+
+  * Added a `--bigwigCoverage` option to `add-bam-track.pl` to support configuring pregenerated
+    coverage histograms from the command line.  Thanks to @loraine-gueguen for the suggestion
+    and implementation! (pull #972, @loraine-gueguen)
 
   * Added a `--category` option to `add-bw-track.pl` and `add-bam-track.pl` to
     set the new track's category. Thanks to @loraine-gueguen for the implementation!
     (pull #911, @loraine-gueguen)
 
-  * Made jbrowse installable using `npm`. @cmdcolin and @enuggetry.
+## Bug fixes
 
-  * Implemented a built-in node.js Express server `jb_run.js` for quick JBrowse launching.
-    @enuggetry
+  * Fixed SEVERE performance regression that basically made flatfile-to-json.pl
+    unusable on Perl 5.18 and higher. Huge thanks to Colin Diesh for tracking
+    this down. (issue #470, pull #912, @cmdcolin)
 
-  * Added an `--unsorted` option to `prepare-refseqs.pl` that formats reference sequences
-    in the same order in which they appear in the input sequence file.  Thanks to
-    @dsenalik for the suggestion and implementation! (pull #924, @dsenalik)
 
-  * Allows for dot-notation instead of JSON (pull #952) for addTracks, addBookmarks,
-    and addStores. https://github.com/GMOD/jbrowse/pull/952. Address security concerns
-    adding JSON to GET (https://nvd.nist.gov/vuln/detail/CVE-2016-6816) @nathandunn.
+  * Fixed issue in which JBrowse crashed when negative numbers were supplied for highlight
+    coordinates in the URL. Thanks to @h2akim for reporting, and @cmdcolin for debugging help.
+    (issue #769, @rbuels)
 
-  * If a track has no `key` set in its track configuration, JBrowse will now look for
-    a `key` in its track metadata, and use that if it is present. Thanks to Loraine
-    Guéguen for the idea (issue #957, pull #958). @rbuels
 
-  * Fixed bug in `maker2jbrowse` script that allows `maker2jbrowse` to be installed
-    in system executable directories, and adds a `--sortMem` option.
-    (pull #877, @cmdcolin)
+  * Fixed a "cannot read property 'offsetLeft'" error when using touch screens without
+    the old simple track selector active. (issue #893, @rbuels)
 
-  * Fixed a cosmetic/styling bug with malformed DOM structure in feature detail popup
-    dialogs.  Thanks to Erik Rasche for noticing and fixing this! (pull #882, @erasche)
 
-  * Added a configuration option that can disable JBrowse's behavior of updating the
-    browser's title text as the view changes. Thanks to Luka Jeran, Primož Hadalin,
-    and Nathan Dunn for this! (pull #904, @lukaw3d)
+  * Fixed bug in which start/stop codons were sometimes not displayed in the sequence
+    track at certain zoom levels (issue #858, pull req #859, @cmdcolin)
+  * Fixed a regression in which the `defaultTracks` configuration variable was no longer
+    respected when set to a comma-separated list. (issue #892, pull #896, @rdhayes)
 
   * Suppress execution of biodb-to-json.pl on sample data while running setup.sh
     on MacOS High Sierra with stock Perl due to an issue with the stock Perl having
@@ -65,56 +101,19 @@
     running indefinitely and taking all available disk space.
     (pull #945, issue #946, @deepakunni3 and @rbuels)
 
+  * Fixed a cosmetic/styling bug with malformed DOM structure in feature detail popup
+    dialogs.  Thanks to Erik Rasche for noticing and fixing this! (pull #882, @erasche)
+
+  * Fixed bug in `maker2jbrowse` script that allows `maker2jbrowse` to be installed
+    in system executable directories, and adds a `--sortMem` option.
+    (pull #877, @cmdcolin)
+
   * Mitigate race condition that could sometimes cause duplicate tracks to be shown
     when the browser is started with the `loc` query parameeter set to the name of
     a feature. Thanks to Colin Diesh for the fix. (issue #567, @cmdcolin)
 
-  * Fixed issue in which JBrowse crashed when negative numbers were supplied for highlight
-    coordinates in the URL. Thanks to @h2akim for reporting, and @cmdcolin for debugging help.
-    (issue #769, @rbuels)
 
-  * Add `--config` command-line option to `add-bw-track.pl` and `add-bam-track.pl`
-    scripts. Thanks to Chris Childers for suggesting this! (issue #620, @rbuels)
 
-  * Fixed a "cannot read property 'offsetLeft'" error when using touch screens without
-    the old simple track selector active. (issue #893, @rbuels)
-
-  * Upgraded to use new Google Analytics API for usage reporting. (@rdhayes)
-
-  * Fixed bug in which start/stop codons were sometimes not displayed in the sequence
-    track at certain zoom levels (issue #858, pull req #859, @cmdcolin)
-
-  * Fixed a regression in which the `defaultTracks` configuration variable was no longer
-    respected when set to a comma-separated list. (issue #892, pull #896, @rdhayes)
-
-  * Made a cosmetic change to Alignments track detail popups, changing "Length on ref" to
-    be displayed as "Seq length on ref", so that it is displayed more usefully next to
-    "Seq length".  Thanks to @colindaven for the suggestion and implementation!
-    (pull #939, @colindaven)
-
-  * Improved the error messages displayed when a JBrowse glyph class fails to load. Thanks
-    to @scottcain and @cmdcolin for tracking down the issue and improving the error
-    handling! (issue #968, @cmdcolin)
-
-  * Added support for an `addFeatures` URL query parameter that can inject features from
-    the URL query string. (issue #976, @nathandunn)
-
-  * Changed the project's `git` workflow to utilize a `dev` branch that is separate from
-    `master`, with `master` only being updated when a new release of JBrowse is published.
-    (issue #975, @enuggetry)
-
-  * Implemented automated deployment of JBrowse releases to GitHub releases and `npm`.
-    Thanks to @abretaud, @nathandunn, @erasche, and @cmdcolin for valuable discussions.
-    (issue #822, pull #979, pull #984, @rbuels)
-
-  * Added a `--bigwigCoverage` option to `add-bam-track.pl` to support configuring pregenerated
-    coverage histograms from the command line.  Thanks to @loraine-gueguen for the suggestion
-    and implementation! (pull #972, @loraine-gueguen)
-
-  * Improved documentation of the `CategoryURL` plugin. (pull #985, @enuggetry)
-
-  * Re-enabled and improved documentation and configurability of the gradient colors in the
-    `NeatCanvasFeatures` plugin. (issue #982, pull #985, @enuggetry)
 
 
 # Release 1.12.3     2017-05-02 19:20:01 America/Los_Angeles

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -6,6 +6,8 @@
     `master`, with `master` only being updated when a new release of JBrowse is published.
     (issue #975, @enuggetry)
 
+  * Update to dojo ecosystem to version 1.13.0
+
   * Implemented npm install of JBrowse and added automated deployment of JBrowse releases to
     GitHub releases and `npm`. Thanks to @abretaud, @nathandunn, @erasche, and @cmdcolin for
     valuable discussions. (issue #822, pull #979, pull #984, @rbuels)


### PR DESCRIPTION
Here are some release notes modifications that categorizes some changes as bug fixes. Also moves some of the changes around to improve readability, being clear about what that security fix with dots addresses is tomcat related, putting the npm changes at the top, etc.