### PR TITLE
colours: increase contrast

### DIFF
--- a/css/track_styles.css
+++ b/css/track_styles.css
@@ -43,7 +43,7 @@ div.hist {
     cursor: pointer;
     min-width: 1px;
     z-index: 10;
-    background-color: #eee;
+    background-color: #2F4F4F;
 
     box-sizing: border-box;
     -moz-box-sizing: border-box;
@@ -58,7 +58,7 @@ div.hist {
 .plus-subfeature,
 .minus-subfeature {
     position:absolute;
-    background-color: #dadada;
+    background-color: #2F4F4F;
     height: 7px;
     min-width: 1px;
     z-index: 12;
@@ -105,7 +105,7 @@ div.hist {
     height: 100%;
 }
 .alignment > .skip, .plus-alignment > .skip, .minus-alignment > .skip {
-    background: url('../img/dark_20x3.png') repeat-x 0 50% white;
+    background: url('../img/dark_20x2.png') repeat-x 0 50% white;
     height: 100%;
     opacity: 0.7;
 }
@@ -126,7 +126,7 @@ div.feature-hist {
 }
 
 .Boolean-transparent {
-    opacity: 0.2;
+    opacity: 0.6;
 }
 
 div.feature2-hist {
@@ -357,7 +357,7 @@ div.transcript-hist {
 .minus-transcript {
     position: absolute;
     height: 11px;
-    background: url('../img/dark_20x3.png') repeat-x 0 4px white;
+    background: url('../img/dark_20x2.png') repeat-x 0 4px white;
     z-index: 6;
     min-width: 1px;
     cursor: pointer;


### PR DESCRIPTION
https://github.com/GMOD/jbrowse/issues/605

For me and multiple users, seeing highly transparent (low opacity) very light grey bars against a light background is not good use of contrast.
I have made colours darker and increased opacity to mitigate this and make objects more visible, which enhances usability.