### PR TITLE
Allow locally installed modules in postinstall

### DIFF
--- a/utils/postinstall.js
+++ b/utils/postinstall.js
@@ -26,6 +26,13 @@ var dirList = [
 async.each(dirList,
     function(item, cb){
         var src = appPath+"/node_modules/"+item.src;
+        
+        //if installed as a dependency of another module, some modules are installed into the local node_modules instead of the parent project's folder 
+        if (!fs.existsSync(src)){
+			src = modPath+"/node_modules/"+item.src;	
+			console.log('using src: ' + src)
+		}
+    
         var trg = modPath+"/src/"+item.trg;
 
         // delete the old dir from src dir and make a current copy


### PR DESCRIPTION
I have a project that includes jbrowse as a dependency in package.json.  As of 1.12.4, jbrowse will get installed to:

./node_modules/@gmod/jbrowse

I dont entirely understand why, but while most of jbrowse's NPM dependencies will be installed to the top-level node_modules folder, all of the git dependencies are being installed into:

./node_modules/@gmod/jbrowse/node_modules

as a result, postinstall.js is unable to find/copy jDataView, json-schema, etc.  I tried to figure out the root cause of this difference, but have no luck.  This patch adds a check to postinstall.js to preferentially look for the module in app_root; however, if that file doesnt exist then look in moduleDir/node_modules.  This appears to fix the issue.