### PR TITLE
NPM module is located at @gmod/jbrowse

### DIFF
--- a/utils/jb_run.js
+++ b/utils/jb_run.js
@@ -13,8 +13,8 @@ var thisPath = process.cwd();
 var jbrowsePath = "./";
 
 // check if jbrowse is a module
-if (fs.pathExistsSync(thisPath+"/node_modules/jbrowse/utils")) {
-	jbrowsePath = "./node_modules/jbrowse";
+if (fs.pathExistsSync(thisPath+"/node_modules/@gmod/jbrowse/utils")) {
+	jbrowsePath = "./node_modules/@gmod/jbrowse";
 }
 
 // command line options

--- a/utils/jb_setup.js
+++ b/utils/jb_setup.js
@@ -12,8 +12,8 @@ var setupScript = "setup.sh";
 var thisPath = process.cwd();
 
 // check if jbrowse is a module
-if (fs.pathExistsSync(thisPath+"/node_modules/jbrowse/"+setupScript)) {
-    shelljs.cd("node_modules/jbrowse");
+if (fs.pathExistsSync(thisPath+"/node_modules/@gmod/jbrowse/"+setupScript)) {
+    shelljs.cd("node_modules/@gmod/jbrowse");
 }
 
 shelljs.exec("./"+setupScript);


### PR DESCRIPTION
Currently if you do a "npm install @gmod/jbrowse" you get main jbrowse code in "node_modules/@gmod/jbrowse"

This fixes some of the accessory scripts to support this. I'm not sure if all node js versions install node_modules paths this way, but I tested v9 and v6

Also, AFAIK, the `npm install jbrowse` didn't install, it needed @gmod/jbrowse, hence this issue