### PR TITLE
go to search completion immediately on click

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -11,6 +11,11 @@
   * Changed the default color for HTMLFeatures features to be a darker gray that
     is easier to see. Many thanks to @colindaven for the fix! (pull #980, @colindaven)
 
+  * When users click on an item in the dropdown autocompletion for the browser search
+    box, the browser will go directly to that item immediately, eliminating the extra
+    step of the user having to click "Go". Many thanks to @enuggetry for noticing the
+    opportunity for this nice usability enhancement! (issue #616, pull #1001, @rbuels)
+
 ## Bug fixes
 
   * Fixed a security issue with JBrowse error messages. Thanks to @GrainGenes for

--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -3126,7 +3126,11 @@ createNavBox: function( parent ) {
          dropDownProto.onClick = function( node ) {
              if( dojo.hasClass(node, 'moreMatches' ) )
                  return null;
-             return oldOnClick.apply( this, arguments );
+
+
+            var ret = oldOnClick.apply( this, arguments );
+            thisB.navigateTo(thisB.locationBox.get('value'))
+            return ret;
          };
     }).call(this);
 


### PR DESCRIPTION
call `Browser.navigateTo` when an item is clicked in the location search dropdown menu, to just go to that item immediately

fixes #616 

just merge if it looks fine