### PR TITLE
Delete git directory of built plugins

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -89,6 +89,7 @@ plugins-min: release-normal
 		rm -rf "$(RELEASE_FULL_DIR)/plugins/$$pname/js"; \
 		mv "$(RELEASE_FULL_DIR)/plugins/$$pname/built/$$pname" "$(RELEASE_FULL_DIR)/plugins/$$pname/js"; \
 		rm -rf "$(RELEASE_FULL_DIR)/plugins/$$pname/built"; \
+		rm -rf "$(RELEASE_FULL_DIR)/plugins/$$pname/.git"; \
 	done
 
 release-min: release-normal plugins-min


### PR DESCRIPTION
When the plugins that have been cloned from git are built by jbrowse the superclean target fails to delete the generated build folders like JBrowse-1.12.4-dev/plugins/BlahPlugin. Reason being, git clean doesn't like to delete git repositories. So, make sure to delete any .git folder from the generated plugin builds. Probably a reasonable thing to do anyways