### PR TITLE
Add "loading screen"

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,16 +109,23 @@
 
                    // create a JBrowse global variable holding the JBrowse instance
                    JBrowse = new Browser( config );
+
                    require.on('error', function(error) {
                        JBrowse.fatalError('Failed to load resource: '+error.info[0]);
                    });
+
+                   JBrowse.afterMilestone('loadRefSeqs', function() { dojo.destroy(dojo.byId('LoadingScreen')); });
         });
     </script>
 
   </head>
 
   <body>
-    <div id="GenomeBrowser" style="height: 100%; width: 100%; padding: 0; border: 0;"></div>
+    <div id="GenomeBrowser" style="height: 100%; width: 100%; padding: 0; border: 0;">
+	  <div id="LoadingScreen" style="padding: 50px;">
+		<h1>Loading...</h1>
+	  </div>
+	</div>
     <div style="display: none">JBrowseDefaultMainPage</div>
   </body>
 </html>

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -35,6 +35,9 @@
     SNP indicator below a SNPCoverage track. Big thanks to Nathan Haigh for the idea
     and implementation! (pull #951, @nathanhaigh)
 
+  * Added a basic loading screen for when the page is initially loading (pull #1008,
+    @cmdcolin)
+
 ## Bug fixes
 
   * Fixed a security issue with JBrowse error messages. Thanks to @GrainGenes for


### PR DESCRIPTION
This PR adds a basic "loading screen" while the browser is waiting to be initialized. Then, after the loadRefSeqs milestone is passed, the text is removed. This helps with slow connections and large refSeqs.json files

This was documented as a customization that users can make to index.html in the configuration guide, but it seems like it could be useful to have it by default? http://gmod.org/wiki/JBrowse_Configuration_Guide#Configure_a_Loading_Page