### PR TITLE
make subfeaturelevel default to 2

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -909,6 +909,11 @@ a.dialog-new-window {
     margin-bottom: 0.8em;
 }
 
+.feature-detail .subfeature-load-button {
+    margin-top: 15px;
+    margin-left: 10px;
+}
+
 .feature-detail .fastaView {
     padding: 0;
     border: 1px solid #aaa;

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -38,7 +38,7 @@
 
   * The global `highResolutionMode` configuration is now set to `auto`, meaning that
     JBrowse by default will now auto-detect high-DPI displays (Apple Retina displays
-    and the like) and draw canvas-based tracks more clearly on them. This capability
+    and similar) and draw canvas-based tracks more clearly on them. This capability
     has been present in the JBrowse code for a long time, but has been turned off
     by default. (@rbuels)
 
@@ -50,6 +50,18 @@
 
   * Added a basic loading screen for when the page is initially loading (pull #1008,
     @cmdcolin)
+
+  * The `subfeatureDetailLevel` configuration variable for tracks now defaults to a value
+    of 2, meaning that the builtin JBrowse default feature detail popup dialogs will only
+    show one level of subfeatures by default. Most feature tracks have only one level of
+    subfeatures anyway, but for very complex data (like gene models with many transcripts,
+    each with many introns and exons), this new default will prevent a rather confusing
+    problem some users were seeing in which JBrowse would seem to 'hang' when clicking a
+    gene model to see its details. Thanks to @cmdcolin for the original implementation of the
+    `subfeatureDetailLevel` configuration variable, @kshefchek for a good bug report that
+    shows it, and @nathandunn and @selewis for valuable discussions.
+    (issue #559, pull #1010, @rbuels)
+
 
 ## Bug fixes
 

--- a/src/JBrowse/View/Track/BlockBased.js
+++ b/src/JBrowse/View/Track/BlockBased.js
@@ -115,7 +115,8 @@ return declare( [Component,DetailsMixin,FeatureFiltererMixin,Destroyable],
      */
     _defaultConfig: function() {
         return {
-            maxFeatureSizeForUnderlyingRefSeq: 250000
+            maxFeatureSizeForUnderlyingRefSeq: 250000,
+            subfeatureDetailLevel: 2
         };
     },
 

--- a/src/JBrowse/View/Track/_FeatureDetailMixin.js
+++ b/src/JBrowse/View/Track/_FeatureDetailMixin.js
@@ -119,7 +119,8 @@ return declare( FeatureDescriptionMixin, {
             }
             else if(layer >= track.config.subfeatureDetailLevel) {
                 var b = domConstruct.create('button', {
-                    innerHTML: 'Load subfeatures...'
+                    className: 'subfeature-load-button',
+                    innerHTML: 'Show subfeatures...'
                 }, container);
                 on(b, 'click', function() {
                     thisB._subfeaturesDetail( track, subfeatures, container, f, layer + 1 );


### PR DESCRIPTION
This is a follow-on to #861, whic makes the feature detail popup only render one layer of subfeatures by default.

Since there is a 'Show subfeatures' button, this new default probably won't have any ill effects.  And it should prevent most problems like the one in #559, in which the feature detail popup for a gene with a great many alternative transcripts (for several hundred features in total) takes upwards of 30 seconds to render all of the subfeature details, blocking the main UI thread all the while.
