### PR TITLE
Fix volvox track coloring

### DIFF
--- a/docs/tutorial/conf_files/volvox.json
+++ b/docs/tutorial/conf_files/volvox.json
@@ -186,7 +186,7 @@
       {
          "track" : "Transcript",
          "description" : 1,
-         "style": { "color": "#E32A3A" },
+         "style": { "color": "#E32A3A", "description": "customdescription" },
          "key" : "CanvasFeatures - transcripts",
          "trackType": "JBrowse/View/Track/CanvasFeatures",
          "feature" : [
@@ -194,7 +194,6 @@
          ],
          "category" : "Transcripts",
          "subfeatures" : true,
-         "style": {"description": "customdescription"},
          "showNoteInAttributes": true,
          "onClick": "{exampleFeatureClick}"
       },


### PR DESCRIPTION
There is a error with the json in the volvox biodb config file that made the coloring on the track get ignored

This restores the color :)