### PR TITLE
Fix hide track labels logic for toggling

### DIFF
--- a/plugins/HideTrackLabels/js/main.js
+++ b/plugins/HideTrackLabels/js/main.js
@@ -70,7 +70,6 @@ return declare( JBrowsePlugin,
                 thisB.showTrackLabels("hide");
             });
         }
-
         dojo.subscribe("/jbrowse/v1/n/tracks/redraw", function(data){
             thisB.showTrackLabels("hide-if");
         });
@@ -84,7 +83,7 @@ return declare( JBrowsePlugin,
      */
     showTrackLabels: function(fn) {
         var direction = 1;
-        var button = dom.byId("hidetitled-btn");
+        var button = dom.byId("hidetitles-btn");
 
         if (fn=="show") {
             if(button) dojo.removeAttr(button,"hidden-titles");
@@ -100,13 +99,15 @@ return declare( JBrowsePlugin,
         }
 
         if (fn=="toggle"){
-            if (button && dojo.hasAttr(button,"hidden-titles")) {     // if hidden, show
-                dojo.removeAttr(button,"hidden-titles");
-                direction = 1;
-            }
-            else {
-                if(button) dojo.attr(button,"hidden-titles","");       // if shown, hide
-                direction = -1;
+            if (button) {
+                if(dojo.hasAttr(button,"hidden-titles")) {     // if hidden, show
+                    dojo.removeAttr(button,"hidden-titles");
+                    direction = 1;
+                }
+                else {
+                    dojo.attr(button,"hidden-titles","");       // if shown, hide
+                    direction = -1;
+                }
             }
         }
         // protect Hide button from clicks during animation


### PR DESCRIPTION
This is a PR that addresses an issue from https://github.com/GMOD/jbrowse/pull/1018

Basically there was a spelling in error in getting the DOM node and then the logic for removing the hidden-titles was not using removeAttr

Sorry bout that! Should really try and reduce complexity of this at some point