### PR TITLE
Fix error with callback

### DIFF
--- a/docs/tutorial/data_files/volvox.subsubparts.gff3.conf
+++ b/docs/tutorial/data_files/volvox.subsubparts.gff3.conf
@@ -4,7 +4,7 @@ urlTemplate = ../../raw/volvox/volvox.subsubparts.gff3
 type = CanvasFeatures
 featureFilter = function(feature) {
     return feature.children()
-}
+ }
 metadata.description = This contains a gene model whose CDS features themselves have stop_codon_read_through subfeatures (sub-sub-subfeatures)
 category = Miscellaneous
 key = GFF3 - sub-subparts


### PR DESCRIPTION
This fixes #1029 by moving the closing bracket away from the first column of the config file

Potentially it would be cool if that wasn't required, but it is explained in the JBrowse config guides that this is necessary