### PR TITLE
Add source back to bigwig features

### DIFF
--- a/src/JBrowse/Store/SeqFeature/BigWig/RequestWorker.js
+++ b/src/JBrowse/Store/SeqFeature/BigWig/RequestWorker.js
@@ -247,7 +247,8 @@ var RequestWorker = declare( null,
 
         var data = {
             start: fmin,
-            end: fmax
+            end: fmax,
+            source: this.source
         };
 
         for( var k in opts )


### PR DESCRIPTION
There was a commit here that deleted this.source from bigwig features 1517728d6d5f140c94d

The MultiBigWig plugin actually depended on the "source" field from bigwig score features for functionality so this plugin doesn't work in 1.14

If we can restore this.source it would help