### PR TITLE
Fix error with running setup.sh twice

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -112,7 +112,7 @@ if [ -f "src/JBrowse/Browser.js" ]; then
     (
         set -e
         check_node
-        npm install yarn
+        [[ -f node_modules/.bin/yarn ]] || npm install yarn
         node_modules/.bin/yarn install
         node_modules/.bin/yarn build
     ) >>setup.log 2>&1;


### PR DESCRIPTION
I was seeing an error happening if I ran setup.sh twice in a row, it would give an error that the command webpack was not found:

```
$ ./setup.sh            
Gathering system information ...done.                                                                                                                                                                       
NOTE: Legacy scripts wig-to-json.pl and bam-to-json.pl have removed from setup. Their functionality has been superseded by add-bam-track.pl and add-bw-track.pl. If you require the old versions, please use
 JBrowse 1.12.3 or earlier.                                                                                                                                                                                 
Installing node.js dependencies and building with webpack ...done.                                                                                                                                          
Installing Perl prerequisites ...done.                                                                                                                                                                      
                                                                                                                                                                                                            
Formatting Volvox example data ...done.                                                                                                                                                                     
To see the volvox example data, browse to http://your.jbrowse.root/index.html?data=sample_data/json/volvox.                                                                                                 
                                                                                                                                                                                                            
Formatting Yeast example data ...done.                                                                                                                                                                      
To see the yeast example data, browse to http://your.jbrowse.root/index.html?data=sample_data/json/yeast.                                                                                                   
$ ./setup.sh                                                                                                                                                                                 
Gathering system information ...done.                                                                                                                                                                       
NOTE: Legacy scripts wig-to-json.pl and bam-to-json.pl have removed from setup. Their functionality has been superseded by add-bam-track.pl and add-bw-track.pl. If you require the old versions, please use
 JBrowse 1.12.3 or earlier.                                                                                                                                                                                 
Installing node.js dependencies and building with webpack ... failed.  See setup.log file for error messages.                                                                                               
setup cannot continue, aborting.                                                                                                                                                                            
                                              
Gathering system information ...
============== System information ====
+ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04 LTS
Release:        18.04
Codename:       bionic
+ uname -a
Linux cdiesh-VirtualBox 4.15.0-20-generic #21-Ubuntu SMP Tue Apr 24 06:16:15 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
+ sw_vers
./setup.sh: line 72: sw_vers: command not found
+ grep MemTotal /proc/meminfo
MemTotal:        3073508 kB
+ echo

+ echo


done.


NOTE: Legacy scripts wig-to-json.pl and bam-to-json.pl have removed from setup. Their functionality has been superseded by add-bam-track.pl and add-bw-track.pl. If you require the old versions, please use JBrowse 1.12.3 or earlier.


Installing node.js dependencies and building with webpack ...
Node v8.10.0 installed at /usr/bin/node with npm 5.6.0
npm WARN rm not removing /home/cdiesh/src/jbrowse/node_modules/.bin/semver as it wasn't installed by /home/cdiesh/src/jbrowse/node_modules/semver
npm WARN rm not removing /home/cdiesh/src/jbrowse/node_modules/.bin/mkdirp as it wasn't installed by /home/cdiesh/src/jbrowse/node_modules/mkdirp
npm WARN rm not removing /home/cdiesh/src/jbrowse/node_modules/.bin/jsesc as it wasn't installed by /home/cdiesh/src/jbrowse/node_modules/jsesc
npm WARN rm not removing /home/cdiesh/src/jbrowse/node_modules/.bin/babylon as it wasn't installed by /home/cdiesh/src/jbrowse/node_modules/babylon
npm WARN rm not removing /home/cdiesh/src/jbrowse/node_modules/@babel/traverse/node_modules/.bin/babylon as it wasn't installed by /home/cdiesh/src/jbrowse/node_modules/@babel/traverse/node_modules/babylon
npm WARN rm not removing /home/cdiesh/src/jbrowse/node_modules/@babel/template/node_modules/.bin/babylon as it wasn't installed by /home/cdiesh/src/jbrowse/node_modules/@babel/template/node_modules/babylon
+ yarn@1.6.0
removed 1292 packages and updated 1 package in 15.685s
yarn install v1.6.0
[1/4] Resolving packages...
success Already up-to-date.
Done in 1.38s.
yarn run v1.6.0
$ webpack
/bin/sh: 1: webpack: not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```


Presumably this is because the `npm install yarn` messes up something from the yarn install. A small reproducible example is just

```
#!/bin/bash
npm install yarn
node_modules/.bin/yarn install
node_modules/.bin/yarn build
```

To some extent they say that yarn is not ideally installed via npm https://yarnpkg.com/lang/en/docs/install/#alternatives-stable but this seems ok as a workaround