### PR TITLE
Support both ID and name indexing in GFF3Tabix

### DIFF
--- a/src/perl5/Bio/JBrowse/Cmd/IndexNames.pm
+++ b/src/perl5/Bio/JBrowse/Cmd/IndexNames.pm
@@ -603,7 +603,7 @@ sub make_names_iterator {
                     $feature = gff3_parse_feature($line);
                     my $Name = $feature->{attributes}{Name} || [];
                     my $ID = $feature->{attributes}{ID} || [];
-                    @names = $Name->[0] ? @$Name : @$ID;
+                    @names = $Name->[0] ? (@$Name, @$ID) : @$ID;
                     last if scalar @names;
                 }
             }


### PR DESCRIPTION
In the current release, when indexing names in GFF3Tabix using `generate-names.pl`, if a record has both **ID** and **Name** attribute, it would only index **Name**, but not **ID**. This is very strange.

This commit would support both ID and name indexing.