### PR TITLE
Fix memory leak on generate-names.pl

### DIFF
--- a/src/perl5/Bio/JBrowse/Cmd/IndexNames.pm
+++ b/src/perl5/Bio/JBrowse/Cmd/IndexNames.pm
@@ -440,9 +440,11 @@ sub make_operation_stream {
     }
 
     return sub {
-        while( @operation_buffer and my $name_record = $record_stream->() ) {
-            #$self->{stats}{namerecs_converted_to_operations}++;
-            push @operation_buffer, $self->make_operations( $name_record );
+        unless( @operation_buffer ) {
+            if( my $name_record = $record_stream->() ) {
+                #$self->{stats}{namerecs_converted_to_operations}++;
+                push @operation_buffer, $self->make_operations( $name_record );
+            }
         }
         return shift @operation_buffer;
     };


### PR DESCRIPTION
There is a pretty large memory leak in generate-names.pl referenced in #1058 

It is pretty clear by looking at a task manager when the memory usage is climbing, so I did a git bisect and just looked at the memory usage of perl each time running generate-names

It narrowed down to this commit https://github.com/GMOD/jbrowse/commit/e34ab06ccbd543a4ad9344440d91c0d5ae2f7af5


I think the specific hunk that is the culprit is this

```
     return sub {
-        unless( @operation_buffer ) {
-            if( my $name_record = $record_stream->() ) {
-                #$self->{stats}{namerecs_converted_to_operations}++;
-                push @operation_buffer, $self->make_operations( $name_record );
-            }
+        while( @operation_buffer and my $name_record = $record_stream->() ) {
+            #$self->{stats}{namerecs_converted_to_operations}++;
+            push @operation_buffer, $self->make_operations( $name_record );
         }

```

I reverted this part of the diff and I am not seeing any issues now. I am not sure why this would cause a memory leak for perl (I'm using 5.22 here)

