### PR TITLE
Auto lower case gff and nclist feature.get arguments

### DIFF
--- a/src/JBrowse/Model/ArrayRepr.js
+++ b/src/JBrowse/Model/ArrayRepr.js
@@ -235,7 +235,7 @@ ArrayRepr.prototype._makeAccessors = function() {
         tags,
         accessors = {
             get: function(field) {
-                var f = this.get.field_accessors[field];
+                var f = this.get.field_accessors[field.toLowerCase()];
                 if( f )
                     return f.call(this);
                 else

--- a/src/JBrowse/Model/SimpleFeature.js
+++ b/src/JBrowse/Model/SimpleFeature.js
@@ -45,7 +45,7 @@ var SimpleFeature = Util.fastDeclare({
      * 'start' and 'end', but everything else is optional.
      */
     get: function(name) {
-        return this.data[ name ];
+        return this.data[ name.toLowerCase() ];
     },
 
     /**

--- a/src/JBrowse/View/Track/WiggleBase.js
+++ b/src/JBrowse/View/Track/WiggleBase.js
@@ -404,7 +404,7 @@ return declare( [BlockBasedTrack,ExportMixin, DetailStatsMixin ], {
                 var store = f.source;
                 var fRect = featureRects[i];
                 var jEnd = fRect.r;
-                var score = f.get(scoreType)||f.get('score');
+                var score = scoreType?f.get(scoreType):f.get('score');
                 for( var j = Math.round(fRect.l); j < jEnd; j++ ) {
                     if ( pixelValues[j] && pixelValues[j]['lastUsedStore'] == store ) {
                         /* Note: if the feature is from a different store, the condition should fail,


### PR DESCRIPTION
This is a PR that adds auto-lower-casing the feature.get('...') argument for NCList ArrayRepr features and SimpleFeature objects

This helps https://github.com/GMOD/jbrowse/issues/1068

I can't forsee any negative consequences because the attributes are already lowercased