### PR TITLE
Fix initial fetch bam

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -3,9 +3,10 @@
 ## Minor improvements
 
  * Added support for the CSI index format for VCF and BAM files! This format enables genomes
-   with chromosomes longer than a gigabase to be used in JBrowse. To enable, use the
-   `csiUrlTemplate` config to point to the file. Thanks to Keiran Raine and others for
-   motivating this! (issue #926, pull #1086, @cmdcolin)
+   with individual chromosomes longer than ~537MB (2^29 bases) to be used in JBrowse. To enable,
+   use the `csiUrlTemplate` config to point to the file. Thanks to Keiran Raine for initial
+   report and Nathan S Watson-Haigh for catching a bug in the initial implementation!
+   (issue #926, pull #1086, @cmdcolin)
 
  * Added a `dontRedispatch` option for GFF3Tabix stores. Example: set `dontRedispatch=region`
    if there are `region` biotype features in the GFF that do not have subfeatures which will

--- a/src/JBrowse/Model/CSIIndex.js
+++ b/src/JBrowse/Model/CSIIndex.js
@@ -105,6 +105,8 @@ return declare( TabixIndex, {
             // the linear index
 
         }
+
+        this.minAlignmentVO = this.firstDataLine;
         deferred.resolve({ success: true });
     },
 

--- a/src/JBrowse/Store/SeqFeature/BAM/File.js
+++ b/src/JBrowse/Store/SeqFeature/BAM/File.js
@@ -86,7 +86,7 @@ var BamFile = declare( null,
         // BGZF block, assuming BGZF blocks are no bigger than 64KB.
         thisB.data.read(
             0,
-            thisB.minAlignmentVO ? thisB.minAlignmentVO.block + 65535 : null,
+            thisB.index.minAlignmentVO ? thisB.index.minAlignmentVO.block + 65535 : null,
             function(r) {
                 try {
                     var uncba;


### PR DESCRIPTION
The initial fetch for BAM was broken due to not referencing the indexes minAlignmentVO (virtual offset) correctly. This actually affected BAI indexed BAM files just due to how it was moved into a separate modules when the CSI indexing format was merged, but should be fixed now.

Thanks so much to @nathanhaigh  for doing some pre-release testing to catch this! Fixes #1097 