### PR TITLE
Fix sequence store tests based on relative URL

### DIFF
--- a/src/JBrowse/Store/SeqFeature/SequenceChunks.js
+++ b/src/JBrowse/Store/SeqFeature/SequenceChunks.js
@@ -34,12 +34,14 @@ return declare( SeqFeatureStore,
  */
     constructor: function(args) {
         this.compress     = args.compress;
-        this.urlTemplate  = args.urlTemplate;
+        this.urlTemplate  = this.getConf('urlTemplate',[]);
         if( ! this.urlTemplate ) {
             throw "no urlTemplate provided, cannot open sequence store";
         }
 
         this.baseUrl      = args.baseUrl;
+        //this.config.baseUrl = args.baseUrl;
+        console.log(this.baseUrl,'aaa');
         this.seqChunkSize = args.seqChunkSize;
     },
 

--- a/tests/js_tests/spec/SequenceChunkStore.spec.js
+++ b/tests/js_tests/spec/SequenceChunkStore.spec.js
@@ -9,8 +9,11 @@ describe( 'sequence chunk store', function() {
                   s = new ChunkStore({
                                          browser: new Browser({ unitTestMode: true }),
                                          refSeq: { name: 'ctgA', start: 1, end: 500001 },
-                                         urlTemplate: "../../../sample_data/json/volvox/seq/{refseq_dirpath}/{refseq}-",
-                                         seqChunkSize: 20000
+                                         config: {
+                                             baseUrl: '.',
+                                             urlTemplate: "../../sample_data/json/volvox/seq/{refseq_dirpath}/{refseq}-",
+                                             seqChunkSize: 20000
+                                         }
                                    });
               });
 


### PR DESCRIPTION
The code for sequence chunk store tests if there was a sub-url were failing based on having baseUrl '/' being passed through. I am not sure that this bug affects actual jbrowse in action, I think that this behaves ok, but by mimicing browser store initialization that other stores use, I modified both the Store class and the test itself to fix

