### PR TITLE
Enable CSI indexes in the Track->Open dialog

### DIFF
--- a/src/JBrowse/Store/SeqFeature/BAM.js
+++ b/src/JBrowse/Store/SeqFeature/BAM.js
@@ -49,7 +49,7 @@ var BAMStore = declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesM
         var csiBlob, baiBlob;
         var browser = args.browser;
 
-        if(this.config.csiUrlTemplate) {
+        if(args.csi || this.config.csiUrlTemplate) {
             csiBlob = args.csi ||
                 new XHRBlob(
                     this.resolveUrl(

--- a/src/JBrowse/Store/SeqFeature/BEDTabix.js
+++ b/src/JBrowse/Store/SeqFeature/BEDTabix.js
@@ -33,7 +33,7 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
         var thisB = this;
         var csiBlob, tbiBlob;
 
-        if(this.config.csiUrlTemplate) {
+        if(args.csi || this.config.csiUrlTemplate) {
             csiBlob = args.csi ||
                 new XHRBlob(
                     this.resolveUrl(

--- a/src/JBrowse/Store/SeqFeature/GFF3Tabix.js
+++ b/src/JBrowse/Store/SeqFeature/GFF3Tabix.js
@@ -38,7 +38,7 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
         this.dontRedispatch = (args.dontRedispatch||"").split( /\s*,\s*/ );
         var csiBlob, tbiBlob;
 
-        if(this.config.csiUrlTemplate) {
+        if(args.csi || this.config.csiUrlTemplate) {
             csiBlob = args.csi ||
                 new XHRBlob(
                     this.resolveUrl(

--- a/src/JBrowse/Store/SeqFeature/VCFTabix.js
+++ b/src/JBrowse/Store/SeqFeature/VCFTabix.js
@@ -47,7 +47,7 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
         var thisB = this;
         var csiBlob, tbiBlob;
 
-        if(this.config.csiUrlTemplate) {
+        if(args.csi || this.config.csiUrlTemplate) {
             csiBlob = args.csi ||
                 new XHRBlob(
                     this.resolveUrl(

--- a/src/JBrowse/View/FileDialog/ResourceList.js
+++ b/src/JBrowse/View/FileDialog/ResourceList.js
@@ -170,12 +170,13 @@ return declare( null, {
                 /\.vcf$/i.test( name )          ? 'vcf'    :
                 /\.vcf\.gz$/i.test( name )      ? 'vcf.gz' :
                 /\.bed\.gz$/i.test( name )      ? 'bed.gz' :
+                /\.gff3?\.gz$/i.test( name )    ? 'gff3.gz':
                 /\.bed$/i.test( name )          ? 'bed'    :
                 /\.(bb|bigbed)$/i.test( name )  ? 'bb'     :
-                /\.gff3?\.gz$/i.test( name )    ? 'gff3.gz':
                 /\.gff3?\.gz.tbi$/i.test( name )? 'gff3.gz.tbi' :
                 /\.vcf.gz.tbi$/i.test( name )   ? 'vcf.gz.tbi'  :
-                /\.bed.gz.tbi$/i.test( name )   ? 'bed.gz.csi'  :
+                /\.bed.gz.tbi$/i.test( name )   ? 'bed.gz.tbi'  :
+                /\.bed.gz.csi/i.test( name )    ? 'bed.gz.csi'  :
                 /\.gff3?\.gz.csi$/i.test( name )? 'gff3.gz.csi'  :
                 /\.vcf.gz.csi$/i.test( name )   ? 'vcf.gz.csi'  :
                 /\.bam.csi$/i.test( name )      ? 'bam.csi'  :

--- a/src/JBrowse/View/FileDialog/ResourceList.js
+++ b/src/JBrowse/View/FileDialog/ResourceList.js
@@ -106,7 +106,11 @@ return declare( null, {
                         { label: "GFF3+bgzip",  value: "gff3.gz"},
                         { label: "Tabix index", value: "vcf.gz.tbi" },
                         { label: "Tabix index", value: "gff3.gz.tbi" },
-                        { label: "Tabix index", value: "bed.gz.tbi" }
+                        { label: "Tabix index", value: "bed.gz.tbi" },
+                        { label: "CSI index", value: "bed.gz.csi" },
+                        { label: "CSI index", value: "vcf.gz.csi" },
+                        { label: "CSI index", value: "gff3.gz.csi" },
+                        { label: "CSI index", value: "bam.csi" }
                     ],
                     value: this.guessType( name ),
                     onChange: function() {
@@ -171,7 +175,10 @@ return declare( null, {
                 /\.gff3?\.gz$/i.test( name )    ? 'gff3.gz':
                 /\.gff3?\.gz.tbi$/i.test( name )? 'gff3.gz.tbi' :
                 /\.vcf.gz.tbi$/i.test( name )   ? 'vcf.gz.tbi'  :
-                /\.bed.gz.tbi$/i.test( name )   ? 'bed.gz.tbi'  :
+                /\.bed.gz.tbi$/i.test( name )   ? 'bed.gz.csi'  :
+                /\.gff3?\.gz.csi$/i.test( name )? 'gff3.gz.csi'  :
+                /\.vcf.gz.csi$/i.test( name )   ? 'vcf.gz.csi'  :
+                /\.bam.csi$/i.test( name )      ? 'bam.csi'  :
                                                   null
         );
     }

--- a/src/JBrowse/View/FileDialog/TrackList/BAMDriver.js
+++ b/src/JBrowse/View/FileDialog/TrackList/BAMDriver.js
@@ -1,9 +1,9 @@
 define([
            'dojo/_base/declare',
-           './_IndexedFileDriver'
+           './_MultiIndexedFileDriver'
        ],
-       function( declare, IndexedFileDriver ) {
-return declare( IndexedFileDriver,  {
+       function( declare, MultiIndexedFileDriver ) {
+return declare( MultiIndexedFileDriver,  {
     name: 'BAM',
     storeType: 'JBrowse/Store/SeqFeature/BAM',
 
@@ -11,9 +11,15 @@ return declare( IndexedFileDriver,  {
     fileConfKey: 'bam',
     fileUrlConfKey: 'urlTemplate',
 
-    indexExtension: 'bam.bai',
-    indexConfKey: 'bai',
-    indexUrlConfKey: 'baiUrlTemplate'
+    indexTypes: [{
+        indexExtension: 'bam.bai',
+        indexConfKey: 'bai',
+        indexUrlConfKey: 'baiUrlTemplate'
+    }, {
+        indexExtension: 'bam.csi',
+        indexConfKey: 'csi',
+        indexUrlConfKey: 'csiUrlTemplate'
+    }]
 });
 
 });

--- a/src/JBrowse/View/FileDialog/TrackList/GFF3TabixDriver.js
+++ b/src/JBrowse/View/FileDialog/TrackList/GFF3TabixDriver.js
@@ -1,9 +1,9 @@
 define([
            'dojo/_base/declare',
-           './_IndexedFileDriver'
+           './_MultiIndexedFileDriver'
        ],
-       function( declare, IndexedFileDriver ) {
-return declare( IndexedFileDriver,  {
+       function( declare, MultiIndexedFileDriver ) {
+return declare( MultiIndexedFileDriver,  {
     name: 'GFF3+Tabix',
     storeType: 'JBrowse/Store/SeqFeature/GFF3Tabix',
 
@@ -11,11 +11,15 @@ return declare( IndexedFileDriver,  {
     fileConfKey: 'file',
     fileUrlConfKey: 'urlTemplate',
 
-    indexExtension: 'gff3.gz.tbi',
-    indexConfKey: 'tbi',
-    indexUrlConfKey: 'tbiUrlTemplate'
-
-
+    indexType: [{
+        ext: 'gff3.gz.tbi',
+        confKey: 'tbi',
+        urlConfKey: 'tbiUrlTemplate'
+    }, {
+        ext: 'gff3.gz.csi',
+        confKey: 'csi',
+        urlConfKey: 'csiUrlTemplate'
+    }]
 });
 
 });

--- a/src/JBrowse/View/FileDialog/TrackList/GFF3TabixDriver.js
+++ b/src/JBrowse/View/FileDialog/TrackList/GFF3TabixDriver.js
@@ -10,15 +10,14 @@ return declare( MultiIndexedFileDriver,  {
     fileExtension: 'gff3.gz',
     fileConfKey: 'file',
     fileUrlConfKey: 'urlTemplate',
-
-    indexType: [{
-        ext: 'gff3.gz.tbi',
-        confKey: 'tbi',
-        urlConfKey: 'tbiUrlTemplate'
+    indexTypes: [{
+        indexExtension: 'gff3.gz.tbi',
+        indexConfKey: 'tbi',
+        indexUrlConfKey: 'tbiUrlTemplate'
     }, {
-        ext: 'gff3.gz.csi',
-        confKey: 'csi',
-        urlConfKey: 'csiUrlTemplate'
+        indexExtension: 'gff3.gz.csi',
+        indexConfKey: 'csi',
+        indexUrlConfKey: 'csiUrlTemplate'
     }]
 });
 

--- a/src/JBrowse/View/FileDialog/TrackList/VCFTabixDriver.js
+++ b/src/JBrowse/View/FileDialog/TrackList/VCFTabixDriver.js
@@ -1,9 +1,9 @@
 define([
            'dojo/_base/declare',
-           './_IndexedFileDriver'
+           './_MultiIndexedFileDriver'
        ],
-       function( declare, IndexedFileDriver ) {
-return declare( IndexedFileDriver,  {
+       function( declare, MultiIndexedFileDriver ) {
+return declare( MultiIndexedFileDriver,  {
     name: 'VCF+Tabix',
     storeType: 'JBrowse/Store/SeqFeature/VCFTabix',
 
@@ -11,9 +11,15 @@ return declare( IndexedFileDriver,  {
     fileConfKey: 'file',
     fileUrlConfKey: 'urlTemplate',
 
-    indexExtension: 'vcf.gz.tbi',
-    indexConfKey: 'tbi',
-    indexUrlConfKey: 'tbiUrlTemplate'
+    indexTypes: [{
+        ext: 'vcf.gz.tbi',
+        confKey: 'tbi',
+        urlConfKey: 'tbiUrlTemplate'
+    }, {
+        ext: 'vcf.gz.csi',
+        confKey: 'csi',
+        urlConfKey: 'csiUrlTemplate'
+    }]
 });
 
 });

--- a/src/JBrowse/View/FileDialog/TrackList/VCFTabixDriver.js
+++ b/src/JBrowse/View/FileDialog/TrackList/VCFTabixDriver.js
@@ -12,13 +12,13 @@ return declare( MultiIndexedFileDriver,  {
     fileUrlConfKey: 'urlTemplate',
 
     indexTypes: [{
-        ext: 'vcf.gz.tbi',
-        confKey: 'tbi',
-        urlConfKey: 'tbiUrlTemplate'
+        indexExtension: 'vcf.gz.tbi',
+        indexConfKey: 'tbi',
+        indexUrlConfKey: 'tbiUrlTemplate'
     }, {
-        ext: 'vcf.gz.csi',
-        confKey: 'csi',
-        urlConfKey: 'csiUrlTemplate'
+        indexExtension: 'vcf.gz.csi',
+        indexConfKey: 'csi',
+        indexUrlConfKey: 'csiUrlTemplate'
     }]
 });
 

--- a/src/JBrowse/View/FileDialog/TrackList/_MultiIndexedFileDriver.js
+++ b/src/JBrowse/View/FileDialog/TrackList/_MultiIndexedFileDriver.js
@@ -21,7 +21,8 @@ return declare( null, {
             // go through the configs and see if there is one for an index that seems to match
             for( var n in configs ) {
                 var c = configs[n];
-                for(const index in this.indexTypes) {
+                for(const m in this.indexTypes) {
+                    var index = this.indexTypes[m];
                     if( Util.basename( c[index.indexConfKey] ? c[index.indexConfKey ].url || c[index.indexConfKey].blob.name : c[index.indexUrlConfKey], '.'+index.indexExtension ) == basename ) {
                         // it's a match, put it in
                         c[this.fileConfKey] = this._makeBlob( resource );
@@ -33,7 +34,8 @@ return declare( null, {
             basename = Util.basename( basename, '.'+this.fileExtension );
             for( var n in configs ) {
                 var c = configs[n];
-                for(const index in this.indexTypes) {
+                for(const m in this.indexTypes) {
+                    var index = this.indexTypes[m];
                     if( Util.basename( c[index.indexConfKey] ? c[index.indexConfKey].url || c[index.indexConfKey].blob.name : c[index.indexUrlConfKey], '.'+index.indexExtension ) == basename ) {
                         // it's a match, put it in
                         c[this.fileConfKey] = this._makeBlob( resource );
@@ -54,7 +56,8 @@ return declare( null, {
 
             return true;
         } else {
-            for(const index in this.indexTypes) {
+            for(const m in this.indexTypes) {
+                var index = this.indexTypes[m];
                 if( resource.type == index.indexExtension ) {
                     var basename = Util.basename(
                         resource.file ? resource.file.name :
@@ -101,6 +104,7 @@ return declare( null, {
 
     // try to merge any singleton file and index stores.  currently can only do this if there is one of each
     finalizeConfiguration: function( configs ) {
+        console.log(configs);
 
     },
 

--- a/src/JBrowse/View/FileDialog/TrackList/_MultiIndexedFileDriver.js
+++ b/src/JBrowse/View/FileDialog/TrackList/_MultiIndexedFileDriver.js
@@ -1,0 +1,125 @@
+define([
+           'dojo/_base/declare',
+           'JBrowse/Util',
+           'JBrowse/Model/FileBlob',
+           'JBrowse/Model/XHRBlob'
+       ],
+       function( declare, Util, FileBlob, XHRBlob ) {
+var uniqCounter = 0;
+return declare( null, {
+
+    tryResource: function( configs, resource ) {
+        if( resource.type == this.fileExtension ) {
+            var basename = Util.basename(
+                resource.file ? resource.file.name :
+                resource.url  ? resource.url       :
+                                ''
+            );
+            if( !basename )
+                return false;
+
+            // go through the configs and see if there is one for an index that seems to match
+            for( var n in configs ) {
+                var c = configs[n];
+                for(const index in this.indexTypes) {
+                    if( Util.basename( c[index.indexConfKey] ? c[index.indexConfKey ].url || c[index.indexConfKey].blob.name : c[index.indexUrlConfKey], '.'+index.indexExtension ) == basename ) {
+                        // it's a match, put it in
+                        c[this.fileConfKey] = this._makeBlob( resource );
+                        return true;
+                    }
+                }
+            }
+            // go through again and look for index files that don't have the base extension in them
+            basename = Util.basename( basename, '.'+this.fileExtension );
+            for( var n in configs ) {
+                var c = configs[n];
+                for(const index in this.indexTypes) {
+                    if( Util.basename( c[index.indexConfKey] ? c[index.indexConfKey].url || c[index.indexConfKey].blob.name : c[index.indexUrlConfKey], '.'+index.indexExtension ) == basename ) {
+                        // it's a match, put it in
+                        c[this.fileConfKey] = this._makeBlob( resource );
+                        return true;
+                    }
+                }
+
+            }
+
+            // otherwise make a new store config for it
+            var newName = this.name+'_'+basename+'_'+uniqCounter++;
+            configs[newName] = {
+                type: this.storeType,
+                name: newName,
+                fileBasename: basename
+            };
+            configs[newName][this.fileConfKey] = this._makeBlob( resource );
+
+            return true;
+        } else {
+            for(const index in this.indexTypes) {
+                if( resource.type == index.indexExtension ) {
+                    var basename = Util.basename(
+                        resource.file ? resource.file.name :
+                        resource.url  ? resource.url       :
+                                        ''
+                        , '.'+index.indexExtension
+                    );
+                    if( !basename )
+                        return false;
+
+                    // go through the configs and look for data files that match like zee.bam -> zee.bam.bai
+                    for( var n in configs ) {
+                        var c = configs[n];
+                        if( Util.basename( c[this.fileConfKey] ? c[this.fileConfKey].url || c[this.fileConfKey].blob.name : c[this.fileUrlConfKey] ) == basename ) {
+                            // it's a match, put it in
+                            c[index.indexConfKey] = this._makeBlob( resource );
+                            return true;
+                        }
+                    }
+                    // go through again and look for data files that match like zee.bam -> zee.bai
+                    for( var n in configs ) {
+                        var c = configs[n];
+                        if( Util.basename( c[this.fileConfKey] ? c[this.fileConfKey].url || c[this.fileConfKey].blob.name : c[this.fileUrlConfKey], '.'+this.fileExtension ) == basename ) {
+                            // it's a match, put it in
+                            c[index.indexConfKey] = this._makeBlob( resource );
+                            return true;
+                        }
+                    }
+
+                    // otherwise make a new store
+                    var newName = this.name+'_'+Util.basename(basename,'.'+this.fileExtension)+'_'+uniqCounter++;
+                    configs[newName] = {
+                        name: newName,
+                        type: this.storeType
+                    };
+
+                    configs[newName][index.indexConfKey] = this._makeBlob( resource );
+                    return true;
+                }
+            }
+        }
+        return false;
+    },
+
+    // try to merge any singleton file and index stores.  currently can only do this if there is one of each
+    finalizeConfiguration: function( configs ) {
+
+    },
+
+    _makeBlob: function( resource ) {
+        var r = resource.file ? new FileBlob( resource.file ) :
+                resource.url  ? new XHRBlob( resource.url )   :
+                                null;
+        if( ! r )
+            throw 'unknown resource type';
+        return r;
+
+    },
+
+    confIsValid: function( conf ) {
+        var valid = false;
+        for(var i in this.indexTypes) {
+            valid |= (conf[this.fileConfKey] || conf[this.fileUrlConfKey]) && ( conf[index.indexConfKey] || conf[index.indexUrlConfKey] || conf[this.fileUrlConfKey] );
+        }
+        return valid;
+    }
+});
+});

--- a/src/JBrowse/View/FileDialog/TrackList/_MultiIndexedFileDriver.js
+++ b/src/JBrowse/View/FileDialog/TrackList/_MultiIndexedFileDriver.js
@@ -120,7 +120,8 @@ return declare( null, {
 
     confIsValid: function( conf ) {
         var valid = false;
-        for(var i in this.indexTypes) {
+        for(var m in this.indexTypes) {
+            var index = this.indexTypes[m];
             valid |= (conf[this.fileConfKey] || conf[this.fileUrlConfKey]) && ( conf[index.indexConfKey] || conf[index.indexUrlConfKey] || conf[this.fileUrlConfKey] );
         }
         return valid;

--- a/tests/js_tests/spec/AddFiles.spec.js
+++ b/tests/js_tests/spec/AddFiles.spec.js
@@ -24,6 +24,13 @@ describe( 'FileDialog BAM driver', function() {
                       expect( confs.foo.bam.blob.name ).toEqual( 'zee.bam' );
                   });
 
+              it( 'can match a simple BAM file with its CSI XHRBlob', function( ) {
+                      var confs = { foo: { csi: { url: 'zee.bam.csi'} } };
+                      expect( (new BAMDriver()).tryResource( confs, { type: 'bam', file: { name: 'zee.bam'} } ) )
+                          .toBeTruthy();
+                      expect( confs.foo.bam.blob.name ).toEqual( 'zee.bam' );
+                  });
+
 
           });
 


### PR DESCRIPTION
This is a method that enables BAM,VCFTabix,GFF3Tabix,BEDTabix to use the CSI index

I did not flesh out the finalizeConfiguration section of the loader because it had some complex logic. Nevertheless, the code stands up ok without it, and loads tracks with multiple index types (can do BAM+BAI, BAM+CSI, VCF+TBI, VCF+CSI, etc)
