### PR TITLE
Reverse order of displayed subfeatures when the parent feature is on …

### DIFF
--- a/src/JBrowse/View/Track/_FeatureDetailMixin.js
+++ b/src/JBrowse/View/Track/_FeatureDetailMixin.js
@@ -114,6 +114,10 @@ return declare( FeatureDescriptionMixin, {
         var thisB = this;
         var subfeatures = f.get('subfeatures');
         if( subfeatures && subfeatures.length ) {
+            if( f.get('strand') == -1 ) {
+                // Feature is on the oposite strand, lets reverse the order of the subfeatures according to their start position
+                subfeatures.sort(function( a, b ) { return b.get('start')-a.get('start') });
+            }
             if( !(track.config.subfeatureDetailLevel != null) || layer < track.config.subfeatureDetailLevel ) {
                 this._subfeaturesDetail( track, subfeatures, container, f, layer + 1 );
             }


### PR DESCRIPTION
When there is more than 1 subfeature to display and their parent feature is on the negative strand, reverse their display order (based on their start coordinate). This should satisfy #1071