### PR TITLE
Use proper histogram calculation for GFF type stores

### DIFF
--- a/src/JBrowse/Store/SeqFeature/GFF3.js
+++ b/src/JBrowse/Store/SeqFeature/GFF3.js
@@ -241,7 +241,7 @@ return declare([ SeqFeatureStore, DeferredFeatures, DeferredStats, GlobalStatsEs
                 let binValue = Math.round( (feat.get('start') - query.start )* binRatio)
                 let binValueEnd = Math.round( (feat.get('end') - query.start )* binRatio)
 
-                for(let bin = binValue; bin < binValueEnd; bin++) {
+                for(let bin = binValue; bin <= binValueEnd; bin++) {
                     histogram[bin] += 1
                     if (histogram[bin] > stats.max) {
                         stats.max = histogram[bin]

--- a/src/JBrowse/Store/SeqFeature/GFF3Tabix.js
+++ b/src/JBrowse/Store/SeqFeature/GFF3Tabix.js
@@ -229,31 +229,23 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
             histogram[bin] = 0
         }
 
-        this.getHeader().then(
-            () => {
-                this.indexedData.getLines(
-                    query.ref || this.refSeq.name,
-                    query.start,
-                    query.end,
-                    line => {
-                        let binValue = Math.round( (line.start - query.start )* binRatio)
-                        let binValueEnd = Math.round( (line.end - query.start )* binRatio)
+        this._getFeatures(query,
+            feature => {
+                let binValue = Math.round( (feature.get('start') - query.start )* binRatio)
+                let binValueEnd = Math.round( (feature.get('end')- query.start )* binRatio)
 
-                        for(let bin = binValue; bin < binValueEnd; bin++) {
-                            histogram[bin] += 1
-                            if (histogram[bin] > stats.max) {
-                                stats.max = histogram[bin]
-                            }
-                        }
-                    },
-                    () => {
-                        successCallback({ bins: histogram, stats: stats})
-                    },
-                    errorCallback
-                );
+                for(let bin = binValue; bin <= binValueEnd; bin++) {
+                    histogram[bin] += 1
+                    if (histogram[bin] > stats.max) {
+                        stats.max = histogram[bin]
+                    }
+                }
+            },
+            () => {
+                successCallback({ bins: histogram, stats: stats})
             },
             errorCallback
-        )
+        );
     },
 
 


### PR DESCRIPTION
This converts to use getFeatures for GFF3Tabix (since multiple isoforms of the same feature doesn't really increase feature density) and crucially adds a less-than-or-equal-to instead of just less-than in the histogram bin fill