### PR TITLE
Add expectRanges to XHRBlob to ensure Range requests give 206 status

### DIFF
--- a/src/JBrowse/Model/XHRBlob.js
+++ b/src/JBrowse/Model/XHRBlob.js
@@ -61,7 +61,8 @@ var XHRBlob = declare( FileBlob,
             start: this.start,
             end: this.end,
             success: callback,
-            failure: failCallback
+            failure: failCallback,
+            range: this.opts.expectRanges
         });
     },
 
@@ -74,7 +75,8 @@ var XHRBlob = declare( FileBlob,
             start: start,
             end: end,
             success: callback,
-            failure: failCallback
+            failure: failCallback,
+            range: this.opts.expectRanges
         });
     },
 

--- a/src/JBrowse/Store/RemoteBinaryFile.js
+++ b/src/JBrowse/Store/RemoteBinaryFile.js
@@ -83,7 +83,7 @@ return declare( null,
                              }, this);
     },
 
-    _fetchChunks: function( url, start, end, callback, errorCallback ) {
+    _fetchChunks: function( url, start, end, callback, errorCallback, expectRanges ) {
         start = start || 0;
 
         // if we already know how big the file is, use that information for the end
@@ -105,19 +105,27 @@ return declare( null,
         // and where we don't, making records for chunks to fetch
         var goldenPath = [];
         if( typeof end != 'number' ) { // if we don't have an end coordinate, we just have to fetch the whole file
-            goldenPath.push({ key: new Chunk( { url: url, start: 0, end: undefined } ) });
+            goldenPath.push({
+                key: new Chunk({
+                    url: url,
+                    start: 0,
+                    end: undefined
+                })
+            });
         }
         else {
             for( var currOffset = start; currOffset <= end; currOffset = goldenPath[goldenPath.length-1].key.end+1 ) {
                 if( existingChunks[0] && existingChunks[0].key.start <= currOffset ) {
                     goldenPath.push( existingChunks.shift() );
                 } else {
-                    goldenPath.push({ key: new Chunk({
-                                          url: url,
-                                          start: currOffset,
-                                          end: existingChunks[0] ? existingChunks[0].key.start-1 : end
-                                      })
-                                    });
+                    goldenPath.push({
+                        key: new Chunk({
+                            url: url,
+                            start: currOffset,
+                            end: existingChunks[0] ? existingChunks[0].key.start-1 : end,
+                            expectRanges: expectRanges
+                        })
+                    });
                 }
             }
         }
@@ -192,7 +200,7 @@ return declare( null,
 
     _fetch: function( request, callback, attempt, truncatedLength ) {
 
-        this._log( 'fetch', request.url, request.start, request.end );
+        this._log( 'fetch', request.url, request.start, request.end, request.expectRanges );
         this._fetchCount++;
 
         attempt = attempt || 1;
@@ -235,8 +243,11 @@ return declare( null,
 
         req.onreadystatechange = dojo.hitch( this, function() {
             if (req.readyState == 4) {
+                if(!Util.isElectron() && req.status == 200 && request.expectRanges == true) {
+                    callback(null, "Server responded with status 200 when status 206 is expected, which is malformed for byte-range request")
+                    return;
+                }
                 if (Util.isElectron() || req.status == 200 || req.status == 206) {
-
                     // if this response tells us the file's total size, remember that
                     this.totalSizes[request.url] = (function() {
                         var contentRange = req.getResponseHeader('Content-Range');
@@ -370,7 +381,8 @@ return declare( null,
                          chunks
                  );
             }),
-            args.failure
+            args.failure,
+            args.range
         );
     },
 

--- a/src/JBrowse/Store/RemoteBinaryFile.js
+++ b/src/JBrowse/Store/RemoteBinaryFile.js
@@ -242,11 +242,13 @@ return declare( null,
         };
 
         req.onreadystatechange = dojo.hitch( this, function() {
-            if (req.readyState == 4) {
+            if (req.readyState == 2) {
                 if(!Util.isElectron() && req.status == 200 && request.expectRanges == true) {
+                    req.abort();
                     callback(null, "Server responded with status 200 when status 206 is expected, which is malformed for byte-range request")
-                    return;
                 }
+            }
+            else if (req.readyState == 4) {
                 if (Util.isElectron() || req.status == 200 || req.status == 206) {
                     // if this response tells us the file's total size, remember that
                     this.totalSizes[request.url] = (function() {

--- a/src/JBrowse/Store/SeqFeature/BAM.js
+++ b/src/JBrowse/Store/SeqFeature/BAM.js
@@ -43,7 +43,8 @@ var BAMStore = declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesM
         var bamBlob = args.bam ||
             new XHRBlob( this.resolveUrl(
                              args.urlTemplate || 'data.bam'
-                         )
+                         ),
+                         { expectRanges: true }
                        );
 
         var csiBlob, baiBlob;
@@ -66,12 +67,12 @@ var BAMStore = declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesM
 
 
         this.bam = new BAMFile({
-                store: this,
-                data: bamBlob,
-                bai: baiBlob,
-                browser: browser,
-                csi: csiBlob,
-                chunkSizeLimit: args.chunkSizeLimit
+            store: this,
+            data: bamBlob,
+            bai: baiBlob,
+            browser: browser,
+            csi: csiBlob,
+            chunkSizeLimit: args.chunkSizeLimit
         });
 
         this.source = ( bamBlob.url  ? bamBlob.url.match( /\/([^/\#\?]+)($|[\#\?])/ )[1] :

--- a/src/JBrowse/Store/SeqFeature/BEDTabix.js
+++ b/src/JBrowse/Store/SeqFeature/BEDTabix.js
@@ -51,7 +51,8 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
 
         var fileBlob = args.file ||
             new XHRBlob(
-                this.resolveUrl( this.getConf('urlTemplate',[]) )
+                this.resolveUrl( this.getConf('urlTemplate',[]) ),
+                { expectRanges: true }
             );
 
         this.indexedData = new TabixIndexedFile(

--- a/src/JBrowse/Store/SeqFeature/BigWig.js
+++ b/src/JBrowse/Store/SeqFeature/BigWig.js
@@ -53,11 +53,7 @@ return declare([ SeqFeatureStore, DeferredFeaturesMixin, DeferredStatsMixin ],
      */
     constructor: function( args ) {
 
-        this.data = args.blob ||
-            new XHRBlob( this.resolveUrl(
-                             args.urlTemplate || 'data.bigwig'
-                         )
-                       );
+        this.data = args.blob || new XHRBlob( this.resolveUrl(args.urlTemplate || 'data.bigwig'), { expectRanges: true });
 
         this.name = args.name || ( this.data.url && new urlObj( this.data.url ).path.replace(/^.+\//,'') ) || 'anonymous';
 

--- a/src/JBrowse/Store/SeqFeature/CRAM.js
+++ b/src/JBrowse/Store/SeqFeature/CRAM.js
@@ -90,7 +90,7 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
         if (args.cram)
             dataBlob = new BlobWrapper(args.cram)
         else if (args.urlTemplate)
-            dataBlob = new BlobWrapper(new XHRBlob(this.resolveUrl(args.urlTemplate || 'data.cram')))
+            dataBlob = new BlobWrapper(new XHRBlob(this.resolveUrl(args.urlTemplate || 'data.cram'), { expectRanges: true }))
         else throw new Error('must provide either `cram` or `urlTemplate`')
 
         let indexBlob

--- a/src/JBrowse/Store/SeqFeature/GFF3Tabix.js
+++ b/src/JBrowse/Store/SeqFeature/GFF3Tabix.js
@@ -56,7 +56,8 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
 
         var fileBlob = args.file ||
             new XHRBlob(
-                this.resolveUrl( this.getConf('urlTemplate',[]) )
+                this.resolveUrl( this.getConf('urlTemplate',[]) ),
+                { expectRanges: true }
             )
 
         this.indexedData = new TabixIndexedFile(

--- a/src/JBrowse/Store/SeqFeature/IndexedFasta.js
+++ b/src/JBrowse/Store/SeqFeature/IndexedFasta.js
@@ -34,10 +34,7 @@ return declare( [ SeqFeatureStore, DeferredFeaturesMixin ],
      */
     constructor: function(args) {
         var fastaBlob = args.fasta ||
-            new XHRBlob( this.resolveUrl(
-                             args.urlTemplate || 'data.fasta'
-                         )
-                       );
+            new XHRBlob( this.resolveUrl(args.urlTemplate || 'data.fasta'), { expectRanges: true });
 
         var faiBlob = args.fai ||
             new XHRBlob( this.resolveUrl(

--- a/src/JBrowse/Store/SeqFeature/TwoBit.js
+++ b/src/JBrowse/Store/SeqFeature/TwoBit.js
@@ -32,9 +32,9 @@ return declare([ SeqFeatureStore, DeferredFeaturesMixin], {
      * @constructs
      */
     constructor: function( args ) {
-        
-        var blob = args.blob || new XHRBlob( this.resolveUrl( args.urlTemplate || 'data.2bit' ) );
-        
+
+        var blob = args.blob || new XHRBlob( this.resolveUrl( args.urlTemplate || 'data.2bit' ), { expectRanges: true } );
+
         this.twoBit = new TwoBitFile({
             data: blob,
             store: this
@@ -75,7 +75,7 @@ return declare([ SeqFeatureStore, DeferredFeaturesMixin], {
             };
         }
 
-        
+
         if( ! has( 'typed-arrays' ) ) {
             this._failAllDeferred( 'This web browser lacks support for JavaScript typed arrays.' );
             return;

--- a/src/JBrowse/Store/SeqFeature/VCFTabix.js
+++ b/src/JBrowse/Store/SeqFeature/VCFTabix.js
@@ -65,7 +65,8 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
 
         var fileBlob = args.file ||
             new XHRBlob(
-                this.resolveUrl( this.getConf('urlTemplate',[]) )
+                this.resolveUrl( this.getConf('urlTemplate',[]) ),
+                { expectRanges: true }
             );
 
         this.indexedData = new VCFIndexedFile(

--- a/src/JBrowse/Store/SeqFeature/VCFTribble.js
+++ b/src/JBrowse/Store/SeqFeature/VCFTribble.js
@@ -63,7 +63,7 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
 
         var fileBlob = args.file ||
             new XHRBlob(
-                this.resolveUrl( this.getConf('urlTemplate',[]) )
+                this.resolveUrl( this.getConf('urlTemplate',[]) ), { expectRanges: true }
             );
 
         this.indexedData = new TribbleIndexedVCFFile(

--- a/src/JBrowse/Store/TabixIndexedFile.js
+++ b/src/JBrowse/Store/TabixIndexedFile.js
@@ -5,7 +5,6 @@ define([
            'JBrowse/Util/TextIterator',
            'JBrowse/Store/LRUCache',
            'JBrowse/Errors',
-           'JBrowse/Model/XHRBlob',
            'JBrowse/Model/BGZip/BGZBlob',
            'JBrowse/Model/TabixIndex',
            'JBrowse/Model/CSIIndex'
@@ -17,7 +16,6 @@ define([
            TextIterator,
            LRUCache,
            Errors,
-           XHRBlob,
            BGZBlob,
            TabixIndex,
            CSIIndex
@@ -136,15 +134,13 @@ return declare( null, {
     },
 
     _readChunkItems: function( chunk, callback ) {
-        var thisB = this;
         var items = [];
-
-        thisB.data.read(chunk.minv.block, chunk.maxv.block - chunk.minv.block + 1, function( data ) {
+        this.data.read(chunk.minv.block, chunk.maxv.block - chunk.minv.block + 1, ( data ) => {
             data = new Uint8Array(data);
             //console.log( 'reading chunk %d compressed, %d uncompressed', chunk.maxv.block-chunk.minv.block+65536, data.length );
             var lineIterator = new TextIterator.FromBytes({ bytes: data, offset: 0 });
             try {
-                thisB._parseItems(
+                this._parseItems(
                     lineIterator,
                     function(i) { items.push(i); },
                     function() { callback(items); }


### PR DESCRIPTION
This PR adds a concept called expectRanges to XHRBlob

It could be argued that this is more severe than a "loud warning" but if a server is doing HTTP 200 for a byte-range request it is very non-compliant

Ref #1132

 