### PR TITLE
Fix problem with dataRoot in config

### DIFF
--- a/src/JBrowse/ConfigManager.js
+++ b/src/JBrowse/ConfigManager.js
@@ -282,10 +282,10 @@ _mergeConfigs: function( a, b ) {
                   && ("object" == typeof a[prop]) ) {
             a[prop] = Util.deepUpdate( a[prop], b[prop] );
         } else if(prop == 'dataRoot') {
-            if(typeof a[prop] == 'undefined' || a[prop] == 'data' && typeof b[prop] != 'undefined' ){
+            if(a[prop] === undefined || a[prop] == 'data' && b[prop] !== undefined ){
                 a[prop] = b[prop];
             }
-        } else if( typeof a[prop] == 'undefined' || typeof b[prop] != 'undefined' ){
+        } else if( a[prop] === undefined || b[prop] !== undefined ){
             a[prop] = b[prop];
         }
     }

--- a/src/JBrowse/ConfigManager.js
+++ b/src/JBrowse/ConfigManager.js
@@ -59,7 +59,7 @@ getFinalConfig: function() {
     return this.finalConfig || ( this.finalConfig = function() {
         var thisB = this;
         var bootstrapConf = this._applyDefaults( lang.clone( this.bootConfig ), this.defaults );
-        return this._loadIncludes( this._fillTemplates( bootstrapConf, bootstrapConf ) )
+        return this._loadIncludes( bootstrapConf )
             .then( function( includedConfig ) {
 
                        // merge the boot config *into* the included config last, so

--- a/src/JBrowse/ConfigManager.js
+++ b/src/JBrowse/ConfigManager.js
@@ -260,18 +260,21 @@ _noRecursiveMerge: function( propName ) {
     return propName == 'datasets';
 },
 
+
 /**
  * Merges config object b into a.  a <- b
  * @private
  */
 _mergeConfigs: function( a, b ) {
+    console.log(a,b);
+    console.log(a.dataRoot,b.dataRoot);
     if( b === null )
         return null;
 
     if( a === null )
         a = {};
 
-    for (var prop in b) {
+    Object.keys(b).forEach(prop => {
         if( prop == 'tracks' && (prop in a) ) {
             a[prop] = this._mergeTrackConfigs( a[prop] || [], b[prop] || [] );
         }
@@ -280,10 +283,15 @@ _mergeConfigs: function( a, b ) {
                   && ("object" == typeof b[prop])
                   && ("object" == typeof a[prop]) ) {
             a[prop] = Util.deepUpdate( a[prop], b[prop] );
+        } else if(prop == 'dataRoot') {
+            if(typeof a[prop] == 'undefined' || a[prop] == 'data' && typeof b[prop] != 'undefined' ){
+                console.log(a[prop],b[prop])
+                a[prop] = b[prop];
+            }
         } else if( typeof a[prop] == 'undefined' || typeof b[prop] != 'undefined' ){
-            a[prop] = b[prop];
+            a[prop] = b[prop]
         }
-    }
+    })
     return a;
 },
 

--- a/src/JBrowse/ConfigManager.js
+++ b/src/JBrowse/ConfigManager.js
@@ -266,15 +266,13 @@ _noRecursiveMerge: function( propName ) {
  * @private
  */
 _mergeConfigs: function( a, b ) {
-    console.log(a,b);
-    console.log(a.dataRoot,b.dataRoot);
     if( b === null )
         return null;
 
     if( a === null )
         a = {};
 
-    Object.keys(b).forEach(prop => {
+    for (var prop in b) {
         if( prop == 'tracks' && (prop in a) ) {
             a[prop] = this._mergeTrackConfigs( a[prop] || [], b[prop] || [] );
         }
@@ -285,13 +283,12 @@ _mergeConfigs: function( a, b ) {
             a[prop] = Util.deepUpdate( a[prop], b[prop] );
         } else if(prop == 'dataRoot') {
             if(typeof a[prop] == 'undefined' || a[prop] == 'data' && typeof b[prop] != 'undefined' ){
-                console.log(a[prop],b[prop])
                 a[prop] = b[prop];
             }
         } else if( typeof a[prop] == 'undefined' || typeof b[prop] != 'undefined' ){
-            a[prop] = b[prop]
+            a[prop] = b[prop];
         }
-    })
+    }
     return a;
 },
 

--- a/tests/data/conf/dataRoot.json
+++ b/tests/data/conf/dataRoot.json
@@ -1,0 +1,3 @@
+{
+  "dataRoot": "notdefault",
+}

--- a/tests/js_tests/spec/ConfigManager.spec.js
+++ b/tests/js_tests/spec/ConfigManager.spec.js
@@ -94,5 +94,67 @@ describe("ConfigManager", function () {
                 expect(config.tracks[0].label).toEqual('zoo');
             });
     });
+
+    it( "should work with dataRoot specified in baseConfig", function() {
+            var m = new ConfigManager({
+                bootConfig: { dataRoot: 'notdefault' },
+                defaults: { dataRoot: 'data' },
+                browser: { fatalError: function(error) { throw error; } },
+                skipValidation: true
+            });
+            var config;
+            expect(m).toBeTruthy();
+            waitsFor( function() { return config; }, 1000 );
+            m.getFinalConfig().then( function(c) {
+                config = c;
+            });
+            runs(function() {
+                expect(config.dataRoot).toEqual('notdefault');
+            });
+    });
+
+
+    it( "should work with dataRoot not specified in baseConfig", function() {
+            var m = new ConfigManager({
+                bootConfig: { foo: 'a' },
+                defaults: { dataRoot: 'data' },
+                browser: { fatalError: function(error) { throw error; } },
+                skipValidation: true
+            });
+            var config;
+            expect(m).toBeTruthy();
+            waitsFor( function() { return config; }, 1000 );
+            m.getFinalConfig().then( function(c) {
+                config = c;
+            });
+            runs(function() {
+                expect(config.dataRoot).toEqual('data');
+            });
+    });
+
+
+    it( "should work with a config with dataRoot in it", function() {
+            var m = new ConfigManager({
+                bootConfig: {
+                    include: [ '../data/conf/dataRoot.json'],
+                },
+                defaults: { dataRoot: 'data' },
+                browser: { fatalError: function(error) { throw error; } },
+                skipValidation: true
+            });
+            var config;
+            expect(m).toBeTruthy();
+            waitsFor( function() { return config; }, 1000 );
+            m.getFinalConfig().then( function(c) {
+                config = c;
+            });
+            runs(function() {
+                expect(config.dataRoot).toEqual('notdefault');
+            });
+    });
+
+
+
+
 });
 });


### PR DESCRIPTION
This PR fixes #627 a bug that is basically that if dataRoot is configured in the config file it is ignored


It solves this in a couple ways

1) It does not fill templates in the initial config. the initial config templates basically only includes the "refSeqs" attribute that references {dataRoot} and the names which also references {dataRoot}. By deferring this, the dataRoot still gets resolved but to the right place after the config is parsed
2) It also avoids the issue of if dataRoot is in config, and &data= is supplied via url (which gets mapped to dataRoot) then it prioritizes the &data= URL

