### PR TITLE
Improve keys formatting in "About this track"

### DIFF
--- a/src/JBrowse/View/Track/BlockBased.js
+++ b/src/JBrowse/View/Track/BlockBased.js
@@ -861,27 +861,45 @@ return declare( [Component,DetailsMixin,FeatureFiltererMixin,Destroyable],
         var fmt = lang.hitch(this, 'renderDetailField', details );
         fmt( 'Name', this.key || this.name );
         var metadata = lang.clone( this.getMetadata() );
-        lang.mixin( metadata, additional );
         delete metadata.key;
         delete metadata.label;
         if( typeof metadata.conf == 'object' )
             delete metadata.conf;
-
+        if (this.browser && this.browser.config && this.browser.config.trackSelector && this.browser.config.trackSelector.renameFacets){
+           var metadataCopy = {};
+           for (var k in metadata){
+              key = this.browser.config.trackSelector.renameFacets[k] || k;
+              metadataCopy[key] = metadata[k];
+           }
+           metadata = metadataCopy;
+        }
         var md_keys = [];
-        for( var k in metadata )
+        for( var k in metadata ){
             md_keys.push(k);
-        // TODO: maybe do some intelligent sorting of the keys here?
-        array.forEach( md_keys, function(key) {
-                          fmt( Util.ucFirst(key), metadata[key] );
-                      });
-
+        }
+        md_keys.sort(function (a, b) {
+           return a.toLowerCase().localeCompare(b.toLowerCase());
+        });
+        for (var i = 0 ; i < md_keys.length ; i++ ){
+           var k = md_keys[i];
+           fmt(this.camelToTitleCase(k), metadata[k]);
+        }
+        for(var k in additional){
+           fmt(k, additional[k]);
+        }
         return details;
     },
 
+    camelToTitleCase: function(str){
+        if (str === str.toLowerCase()){
+            return Util.ucFirst(str.replace(/_/g, " "));
+        } else {
+            return str;
+        }
+    },
+
     getMetadata: function() {
-        return ( this.browser && this.browser.trackMetaDataStore ? this.browser.trackMetaDataStore.getItem(this.name) :
-                                          this.config.metadata ? this.config.metadata :
-                                                                 {} ) || {};
+        return this.config.metadata || this.browser && this.browser.trackMetaDataStore && this.browser.trackMetaDataStore.getItem(this.name) || {};
     },
 
     setPinned: function( p ) {

--- a/src/JBrowse/View/Track/BlockBased.js
+++ b/src/JBrowse/View/Track/BlockBased.js
@@ -868,7 +868,7 @@ return declare( [Component,DetailsMixin,FeatureFiltererMixin,Destroyable],
         if (this.browser && this.browser.config && this.browser.config.trackSelector && this.browser.config.trackSelector.renameFacets){
            var metadataCopy = {};
            for (var k in metadata){
-              key = this.browser.config.trackSelector.renameFacets[k] || k;
+              var key = this.browser.config.trackSelector.renameFacets[k] || k;
               metadataCopy[key] = metadata[k];
            }
            metadata = metadataCopy;


### PR DESCRIPTION
Changes:
- use this.config.metadata if we can, trackMetaDataStore mangles the keys
- if trackSelector.renameFacets was defined, use the formatted keys provided
- instead of blanket ucFirst: only apply if all lowercase, and also swap underscores for spaces to show camel case nicer
- sort keys alphabetically (instead of current random order)

Why:
I'm setting up a fairly large and heterogeneous tracks display. An example URL on a perennial and unstable test site that nobody should rely on, but currently shows a vaguely correct picture is:
http://test.parasite.wormbase.org/jbrowse/index.html?data=%2Fjbrowse-data%2Fbursaphelenchus_xylophilus_prjea64437%2Fdata
I am aggregating data into faceted track displays. They work fantastically - I believe it is genuinely possible to use the display to find relevant tracks there among thousands.

I can't fit all the metadata I have into facets, so I pick the important ones, and want the user to access the rest in "About this track". Unfortunately some of the data there comes out mangled. I found that it happens in this code here, and changed it. I am aware of `fmtDetailField_*`, but I think this patch will be better, and I think it will also work for others.