### PR TITLE
Create standalone entrypoint for manual instantiation

### DIFF
--- a/src/JBrowse/standalone.js
+++ b/src/JBrowse/standalone.js
@@ -1,0 +1,16 @@
+import 'babel-polyfill'
+
+require([
+    'JBrowse/Browser',
+    'css!../../css/genome.scss',
+
+    // instruct build/glob-loader.js to insert includes for every bit of JBrowse and plugin code
+    //!! glob-loader, please include every JBrowse and plugin module here
+
+],
+function (
+    Browser
+) {
+    window.Browser = Browser;
+});
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ const AUTOPREFIXER_BROWSERS = [
 var webpackConf = {
     entry: {
         main: "src/JBrowse/main",
+        browser: "src/JBrowse/standalone"
     },
     plugins: [
         new CleanWebpackPlugin(['dist']),


### PR DESCRIPTION
This creates a standalone entry point where a user can manually initialize the Browser object for #1094 

Then you can create a minimal index.html with something like

```
<!DOCTYPE html>
<html>
  <head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
    <title>JBrowse</title>

    <script type="text/javascript">
        window.onerror=function(msg){
            if( document.body )
                document.body.setAttribute("JSError",msg);
        }
        window.addEventListener('load', () => {
            var JBrowse = new Browser({
                containerID: 'GenomeBrowser',
                dataRoot: 'sample_data/json/volvox'
            })
        });
    </script>

    <style>
        html, body, div.jbrowse {
            margin: 0;
            padding: 0;
            height: 100%;
            width: 100%;
        }
    </style>
    <script type="text/javascript" src="dist/browser.bundle.js" charset="utf-8"></script>
  </head>

  <body>
    <div class="jbrowse" id="GenomeBrowser">
      <div id="LoadingScreen" style="padding: 50px;">
        <h1>Loading...</h1>
      </div>
    </div>
  </body>
</html>

```


One thing to verify is that the npm distribution also contains this file and that it could be used via NPM, e.g. the requested sort of use case was to get


`import Browser from '@gmod/jbrowse'`