### PR TITLE
Fix parsing of the release notes markdown

### DIFF
--- a/build/format_release_notes.pl
+++ b/build/format_release_notes.pl
@@ -1,12 +1,17 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-
 use Text::Markdown 'markdown';
 
-local $/;
-my $html = markdown( scalar <> );
+my $release = "";
+while(<>) {
+    last if /^# /;
+    $release .= $_;
+}
+
+my $html = markdown( $release );
 $html =~ s!issue \#(\d+)!<a href="https://github.com/gmod/jbrowse/issues/$1">issue #$1</a>!g;
 $html =~ s!pull ( request)?\#(\d+)!<a href="https://github.com/gmod/jbrowse/pull/$2">issue #$2</a>!g;
-$html =~ s!(\W)\@([-\w]+)!$1<a href="https://github.com/$2">\@$2</a>!g;
+$html =~ s!(\(|\ )\@([-\w]+)!$1<a href="https://github.com/$2">\@$2</a>!g;
+
 print $html;


### PR DESCRIPTION
This PR does two things

1) Only formatting the release notes for the {{NEXT}} release
2) Checking for only "space" or "open paren" before a github username, specifically so NPM links to the @gmod organization like @gmod/jbrowse for example aren't broken.

These things combined could facilitate automatically creating a blogpost a little easier

