### PR TITLE
Handled a case that str is not a string

### DIFF
--- a/src/JBrowse/Util.js
+++ b/src/JBrowse/Util.js
@@ -38,7 +38,7 @@ Util = {
     },
 
     escapeHTML: function( str ) {
-        return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        return str.toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     },
 
     /**


### PR DESCRIPTION
Added toString() because we faced an issue where str is not a string and replace() cannot be called while testing intermine integration

If you think this place is not a good place to put toString(), feel free to change it.