### PR TITLE
Remove the zoomLevel = 1/200

### DIFF
--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -1019,8 +1019,7 @@ initView: function() {
                   elem: this.viewElem,
                   config: this.config.view,
                   stripeWidth: 250,
-                  refSeq: this.refSeq,
-                  zoomLevel: 1/200
+                  refSeq: this.refSeq
                 });
 
         dojo.connect( this.view, "onFineMove",   this, "onFineMove"   );

--- a/src/JBrowse/GenomeView.js
+++ b/src/JBrowse/GenomeView.js
@@ -2050,6 +2050,9 @@ showVisibleBlocks: function(updateHeight, pos, startX, endX, finishCallback) {
         Math.round(this.pxToBp(this.offset
                                + (this.stripeCount * this.stripeWidth)));
 
+    // Track update will be carried after the maxVisible has a value
+    if (!this.maxVisible()) return;
+    
     let showingPromises = []
     this.overviewTrackIterate(function(track, view) {
         showingPromises.push( new Promise((resolve,reject) => {


### PR DESCRIPTION
Sometimes, initial setting of ```zoomLevel = 1/200``` gives inconsistent view having big margin.
It would be nice to have it computed on-the-fly.

![jbrowse_dd_smes_g4_131_103648__108802](https://user-images.githubusercontent.com/3864647/44391277-ac720680-a52f-11e8-95f6-2a6ce08227e6.png)

The above view will be rendered as below with this PR.

![jbrowse_dd_smes_g4_131_103648__108802_-__private_browsing_](https://user-images.githubusercontent.com/3864647/44391336-d3303d00-a52f-11e8-9f95-5caafc84fa62.png)



