### PR TITLE
Add region stats mixin that has correction for max score

### DIFF
--- a/src/JBrowse/Store/SeqFeature/BED.js
+++ b/src/JBrowse/Store/SeqFeature/BED.js
@@ -8,6 +8,7 @@ define( [
             'JBrowse/Store/DeferredFeaturesMixin',
             'JBrowse/Store/DeferredStatsMixin',
             'JBrowse/Store/SeqFeature/GlobalStatsEstimationMixin',
+            'JBrowse/Store/SeqFeature/RegionStatsMixin',
             'JBrowse/Model/XHRBlob',
             './BED/Parser'
         ],
@@ -21,11 +22,12 @@ define( [
             DeferredFeatures,
             DeferredStats,
             GlobalStatsEstimationMixin,
+            RegionStatsMixin,
             XHRBlob,
             Parser
         ) {
 
-return declare([ SeqFeatureStore, DeferredFeatures, DeferredStats, GlobalStatsEstimationMixin ],
+return declare([ SeqFeatureStore, DeferredFeatures, DeferredStats, GlobalStatsEstimationMixin, RegionStatsMixin ],
 
  /**
   * @lends JBrowse.Store.SeqFeature.BED

--- a/src/JBrowse/Store/SeqFeature/BEDTabix.js
+++ b/src/JBrowse/Store/SeqFeature/BEDTabix.js
@@ -8,6 +8,7 @@ define([
             'JBrowse/Store/DeferredFeaturesMixin',
             'JBrowse/Store/TabixIndexedFile',
             'JBrowse/Store/SeqFeature/IndexedStatsEstimationMixin',
+            'JBrowse/Store/SeqFeature/RegionStatsMixin',
             'JBrowse/Model/XHRBlob',
             'JBrowse/Model/SimpleFeature',
             './BED/Parser'
@@ -22,12 +23,13 @@ define([
             DeferredFeaturesMixin,
             TabixIndexedFile,
             IndexedStatsEstimationMixin,
+            RegionStatsMixin,
             XHRBlob,
             SimpleFeature,
             Parser
         ) {
 
-return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, IndexedStatsEstimationMixin ], {
+return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, IndexedStatsEstimationMixin, RegionStatsMixin ], {
 
     constructor: function( args ) {
         var thisB = this;

--- a/src/JBrowse/Store/SeqFeature/GFF3.js
+++ b/src/JBrowse/Store/SeqFeature/GFF3.js
@@ -11,6 +11,7 @@ define( [
             'JBrowse/Store/DeferredFeaturesMixin',
             'JBrowse/Store/DeferredStatsMixin',
             'JBrowse/Store/SeqFeature/GlobalStatsEstimationMixin',
+            'JBrowse/Store/SeqFeature/RegionStatsMixin',
             'JBrowse/Model/XHRBlob'
         ],
         function(
@@ -24,10 +25,11 @@ define( [
             DeferredFeatures,
             DeferredStats,
             GlobalStatsEstimationMixin,
+            RegionStatsMixin,
             XHRBlob,
         ) {
 
-return declare([ SeqFeatureStore, DeferredFeatures, DeferredStats, GlobalStatsEstimationMixin ],
+return declare([ SeqFeatureStore, DeferredFeatures, DeferredStats, GlobalStatsEstimationMixin, RegionStatsMixin ],
 
  /**
   * @lends JBrowse.Store.SeqFeature.GFF3
@@ -195,66 +197,6 @@ return declare([ SeqFeatureStore, DeferredFeatures, DeferredStats, GlobalStatsEs
             f.subfeatures = sub;
 
         return f;
-    },
-
-
-    getRegionFeatureDensities(query, successCallback, errorCallback) {
-        let numBins
-        let basesPerBin
-
-        if (query.numBins) {
-            numBins = query.numBins;
-            basesPerBin = (query.end - query.start)/numBins
-        } else if (query.basesPerBin) {
-            basesPerBin = query.basesPerBin || query.ref.basesPerBin
-            numBins = Math.ceil((query.end-query.start)/basesPerBin)
-        } else {
-            throw new Error('numBins or basesPerBin arg required for getRegionFeatureDensities')
-        }
-
-        const statEntry = (function (basesPerBin, stats) {
-            for (var i = 0; i < stats.length; i++) {
-                if (stats[i].basesPerBin >= basesPerBin) {
-                    return stats[i]
-                }
-            }
-            return undefined
-        })(basesPerBin, [])
-
-        const stats = {}
-        stats.basesPerBin = basesPerBin
-
-        stats.scoreMax = 0
-        stats.max = 0
-        const firstServerBin = Math.floor( query.start / basesPerBin)
-        const histogram = []
-        const binRatio = 1 / basesPerBin
-
-        let binStart
-        let binEnd
-
-        for (var bin = 0 ; bin < numBins ; bin++) {
-            histogram[bin] = 0
-        }
-
-        this._getFeatures(query,
-            feat => {
-                let binValue = Math.round( (feat.get('start') - query.start )* binRatio)
-                let binValueEnd = Math.round( (feat.get('end') - query.start )* binRatio)
-
-                for(let bin = binValue; bin <= binValueEnd; bin++) {
-                    histogram[bin] += 1
-                    if (histogram[bin] > stats.max) {
-                        stats.max = histogram[bin]
-                    }
-                }
-            },
-            () => {
-                successCallback({ bins: histogram, stats: stats})
-            },
-            errorCallback
-        );
-
     },
 
     /**

--- a/src/JBrowse/Store/SeqFeature/RegionStatsMixin.js
+++ b/src/JBrowse/Store/SeqFeature/RegionStatsMixin.js
@@ -1,0 +1,77 @@
+/**
+ * Mixin that adds getRegionFeatureDensities method to a store
+ */
+
+define([
+           'dojo/_base/declare',
+       ],
+       function( declare ) {
+
+return declare( null, {
+
+    getRegionFeatureDensities(query, successCallback, errorCallback) {
+        let numBins
+        let basesPerBin
+
+        this.scoreMax = this.scoreMax || 0;
+
+        if (query.numBins) {
+            numBins = query.numBins;
+            basesPerBin = (query.end - query.start)/numBins
+        } else if (query.basesPerBin) {
+            basesPerBin = query.basesPerBin || query.ref.basesPerBin
+            numBins = Math.ceil((query.end-query.start)/basesPerBin)
+        } else {
+            throw new Error('numBins or basesPerBin arg required for getRegionFeatureDensities')
+        }
+
+        const statEntry = (function (basesPerBin, stats) {
+            for (var i = 0; i < stats.length; i++) {
+                if (stats[i].basesPerBin >= basesPerBin) {
+                    return stats[i]
+                }
+            }
+            return undefined
+        })(basesPerBin, [])
+
+        const stats = {}
+        stats.basesPerBin = basesPerBin
+
+        stats.max = 0
+        const firstServerBin = Math.floor( query.start / basesPerBin)
+        const histogram = []
+        const binRatio = 1 / basesPerBin
+
+        let binStart
+        let binEnd
+
+        for (var bin = 0 ; bin < numBins ; bin++) {
+            histogram[bin] = 0
+        }
+        this._getFeatures(query,
+            feature => {
+                let binValue = Math.round( (feature.get('start') - query.start )* binRatio)
+                let binValueEnd = Math.round( (feature.get('end')- query.start )* binRatio)
+                for(let bin = binValue; bin <= binValueEnd; bin++) {
+                    if(bin >= 0 && bin < numBins) {
+                        histogram[bin] = (histogram[bin] || 0) + 1
+                        if (histogram[bin] > stats.max) {
+                            stats.max = histogram[bin]
+                            if(stats.max > this.scoreMax) {
+                                this.scoreMax = stats.max
+                            }
+                        }
+                    }
+                }
+            },
+            () => {
+                stats.max = this.scoreMax
+                successCallback({ bins: histogram, stats: stats})
+            },
+            errorCallback
+        );
+
+    }
+
+});
+});


### PR DESCRIPTION
This is a PR to address part of #1192


This PR adds a function to track the "max score" on the store.maxScore property that is updated for the max over the region. This is because if this is not done, the stats.max value returned by getRegionFeatureDensity over a small region become smaller than the actual max over the view causing the histogram to set the Y scale to a small value when the actual data is larger

This also extracts the region stats into a mixin that can be applied to other store classes, so BED and BEDTabix are added here