### PR TITLE
Add failure callback to tenaciousFetch

### DIFF
--- a/src/JBrowse/Model/XHRBlob.js
+++ b/src/JBrowse/Model/XHRBlob.js
@@ -59,6 +59,8 @@ function fetchBinaryRange(url, start, end) {
             responseDate,
             buffer: Buffer.from(arrayBuffer),
         }))
+    }, res => {
+        throw new Error(`HTTP ${res.status} when fetching ${url} bytes ${start}-${end}`)
     })
   }
   const globalCache = new HttpRangeFetcher({


### PR DESCRIPTION
Resolves #1180 (I think)

Add failure callback since tenaciousFetch throws an error when the retries run out. 


