### PR TITLE
Add categoryOrder configuration

### DIFF
--- a/docs/site/track_selectors.md
+++ b/docs/site/track_selectors.md
@@ -63,5 +63,6 @@ There are some other configuration variables that can be used to customize the d
 |Option|Value|
 |------|-----|
 |`trackSelector→sortHierarchical`|Can be true or false. If true, categories and tracks are sorted in alphabetical order. If false, tracks will be loaded specifically in the order that they are specified in the tracklist configuration files. Default:true. Added in JBrowse 1.11.5|
-|`trackSelector→collapsedCategories`|A comma separated list of categories from the trackList that will be collapsed initially. This helps when many tracks are loaded in the trackList but you want to collapse certain categories when the user first loads. If there are subcategories specified using slashes, don't use spaces around the slashes. Default:none. Added in JBrowse 1.11.5|
+|`trackSelector→collapsedCategories`|A comma separated list of categories from the trackList that will be collapsed initially. This helps when many tracks are loaded in the trackList but you want to collapse certain categories when the user first loads. If there are subcategories specified using slashes. Added in JBrowse 1.11.5|
+|`trackSelector→categoryOrder`|A comma separated list of categories which specifies their order. Note that if the there are nested subcategories e.g. the Quantitative/Density in the volvox example, then you can specify a subcategory and it makes the whole Quantitative section sort to the top. Example: categoryOrder=VCF,Transcripts,Quantitative/Density,BAM. Added in JBrowse 1.15.4|
 

--- a/jbrowse.conf
+++ b/jbrowse.conf
@@ -6,8 +6,7 @@
 # description = Browser for O. sativa transcripts and RNA-seq data,
 #   produced by the Smith laboratory at Example State University.
 
-## uncomment and edit the example below to configure a faceted track
-## selector
+## uncomment and edit the example below to configure a faceted track selector
 # [trackSelector]
 # type = Faceted
 # displayColumns =
@@ -15,25 +14,31 @@
 #   + key
 #   + organism
 #   + technique
-## optionally turn off sorting for the hierarchical track selector
-# sortHierarchical = false
-## set collapsed categories for the hierarchical track selector, no spaces around slash separator
-# collapsedCategories = Reference sequence,Quantitative/XY Plot
 ## optionally sort the faceted track selector by column (use the names from displayColumns)
 # initialSortColumn=label
-## optionally give different names to some of the data facets
-## displayed in the track selector
+## optionally give different names to some of the data facets using renameFacets
 # [trackSelector.renameFacets]
 # submission = Submission ID
 # developmental-stage = Conditions
 # cell-line = Cell Line
 # key = Dataset
 # label = Track
+
+## uncomment this section to get hierarchical trackselector options
+# [trackSelector]
+## optionally turn off sorting for the hierarchical track selector
+# sortHierarchical = false
+## set collapsed categories for the hierarchical track selector
+# collapsedCategories = Reference sequence,Quantitative / XY Plot
+## set category ordering in the hierarchical track selector
+# categoryOrder = BAM, Transcripts, Quantitative/Density, VCF
+
 ## configure where to get metadata about tracks.  always indexes the
 ## `metadata` part of each track config, but this can be used to load
 ## additional metadata from CSV or JSON urls
 # [trackMetadata]
 # sources = data/trackMetadata.csv
+
 
 [GENERAL]
 
@@ -47,15 +52,12 @@
 ## hide open genome option
 #hideGenomeOptions = true
 
-## enable or disable high resolution rendering for canvas features 
-## default: 'disabled' since this is a beta feature
-## use 'auto' to auto-detect settings on the users browser
-## use a number to specify a custom backing store ratio on the users browser
-# highResolutionMode=disabled
+## enable or disable high resolution rendering for canvas features. set to auto, disabled, or numerical scaling factor. default: 2
+# highResolutionMode=auto
 
 ## uncomment to change the default sort order of the reference
 ## sequence dropdown
-# refSeqOrder = length ascending
+# refSeqOrder = length descending
 
 
 ## to set a default data directory other than 'data', uncomment and

--- a/src/JBrowse/View/TrackList/Hierarchical.js
+++ b/src/JBrowse/View/TrackList/Hierarchical.js
@@ -38,7 +38,7 @@ return declare(
 
     categoryFacet: 'category',
 
-    constructor: function( args ) {
+    constructor( args ) {
         this.categories = {};
         this.config=
             lang.mixin({
@@ -48,7 +48,7 @@ return declare(
 
         this._loadState();
     },
-    postCreate: function() {
+    postCreate() {
         this.placeAt( this.browser.container );
 
         // subscribe to commands coming from the the controller
@@ -64,7 +64,7 @@ return declare(
                                 lang.hitch( this, 'deleteTracks' ));
     },
 
-    buildRendering: function() {
+    buildRendering() {
         this.inherited('buildRendering',arguments);
 
         var topPane = new ContentPane({ className: 'header' });
@@ -83,8 +83,22 @@ return declare(
         );
         this._updateTextFilterControl();
     },
+    induceCategoryOrder(tracks, categoryOrder) {
+        const order = categoryOrder.split(",").map(s => s.trim()).map(s => s.split("/").map(s => s.trim()).join('/'))
+        tracks.forEach(t => {
+            if(t.category) {
+                t.cat = t.category.trim().split('/').map(s=>s.trim()).join('/')
+            }
+        })
+        var unordered = tracks.filter(t => order.indexOf(t.cat) === -1);
+        var ordered = tracks.filter(t => order.indexOf(t.cat) !== -1);
+        ordered.sort((a, b) => {
+            return order.indexOf(a.cat) - order.indexOf(b.cat);
+        });
+        return ordered.concat(unordered)
+    },
 
-    startup: function() {
+    startup() {
         this.inherited('startup', arguments );
 
         var tracks = [];
@@ -118,18 +132,7 @@ return declare(
                     categories: {}
                 };
                 if( this.config.categoryOrder ) {
-                    const order = this.config.categoryOrder.split(",").map(s => s.trim()).map(s => s.split("/").map(s => s.trim()).join('/'))
-                    tracks.forEach(t => {
-                        if(t.category) {
-                            t.cat = t.category.trim().split('/').map(s=>s.trim()).join('/')
-                        }
-                    })
-                    var unordered = tracks.filter(t => order.indexOf(t.cat) === -1);
-                    var ordered = tracks.filter(t => order.indexOf(t.cat) !== -1);
-                    ordered.sort((a, b) => {
-                        return order.indexOf(a.cat) - order.indexOf(b.cat);
-                    });
-                    tracks = ordered.concat(unordered)
+                    tracks = this.induceCategoryOrder(tracks, this.config.categoryOrder)
                 }
 
                 this.addTracks( tracks, true );

--- a/src/JBrowse/View/TrackList/Hierarchical.js
+++ b/src/JBrowse/View/TrackList/Hierarchical.js
@@ -5,10 +5,8 @@ define(['dojo/_base/declare',
         'dojo/query',
         'dojo/on',
         'dojo/json',
-
         'dijit/TitlePane',
         'dijit/layout/ContentPane',
-
         'JBrowse/Util',
         './_TextFilterMixin'
        ],
@@ -20,10 +18,8 @@ define(['dojo/_base/declare',
            query,
            on,
            JSON,
-
            TitlePane,
            ContentPane,
-
            Util,
            _TextFilterMixin
        ) {
@@ -121,12 +117,14 @@ return declare(
                     tracks: {},
                     categories: {}
                 };
-                if(this.config.categoryOrder) {
+                if( this.config.categoryOrder ) {
                     const order = this.config.categoryOrder.split(",").map(s => s.trim())
-                    tracks.sort((a, b) => {
-                        if(order.indexOf(a.category) == -1 || order.indexOf(b.category) == -1) return 1;
+                    var unordered = tracks.filter(t => order.indexOf(t.category) === -1);
+                    var ordered = tracks.filter(t => order.indexOf(t.category) !== -1);
+                    ordered.sort((a, b) => {
                         return order.indexOf(a.category) - order.indexOf(b.category);
                     });
+                    tracks = ordered.concat(unordered)
                 }
 
                 this.addTracks( tracks, true );

--- a/src/JBrowse/View/TrackList/Hierarchical.js
+++ b/src/JBrowse/View/TrackList/Hierarchical.js
@@ -92,46 +92,52 @@ return declare(
         this.inherited('startup', arguments );
 
         var tracks = [];
-        var thisB = this;
         var categoryFacet = this.get('categoryFacet');
         var sorter;
         if(this.config.sortHierarchical) {
-            sorter=[ { attribute: categoryFacet.toLowerCase()},
-                     { attribute: 'key' },
-                     { attribute: 'label' }
-                   ];
+            sorter = [
+                { attribute: categoryFacet.toLowerCase() },
+                { attribute: 'key' },
+                { attribute: 'label' }
+            ];
         }
 
         // add initally collapsed categories to the local storage
-        var arr=(this.get('collapsedCategories')||"").split(",");
-        for(var i=0; i<arr.length;i++) {
-            lang.setObject('collapsed.'+arr[i],true,this.state);
+        var arr = (this.get('collapsedCategories') || "").split(",");
+        for(var i = 0; i < arr.length; i++) {
+            lang.setObject('collapsed.' + arr[i], true, this.state);
         }
         this._saveState();
 
-        this.get('trackMetaData').fetch(
-            { onItem: function(i) {
-                  if( i.conf )
-                      tracks.push( i );
-              },
-              onComplete: function() {
-                  // make a pane at the top to hold uncategorized tracks
-                  thisB.categories.Uncategorized =
-                      { pane: new ContentPane({ className: 'uncategorized' }).placeAt( thisB.containerNode ),
-                        tracks: {},
-                        categories: {}
-                      };
+        this.get('trackMetaData').fetch({
+            onItem: function(i) {
+                if( i.conf )
+                    tracks.push( i );
+            },
+            onComplete: () => {
+                // make a pane at the top to hold uncategorized tracks
+                this.categories.Uncategorized = {
+                    pane: new ContentPane({ className: 'uncategorized' }).placeAt( this.containerNode ),
+                    tracks: {},
+                    categories: {}
+                };
+                if(this.config.categoryOrder) {
+                    const order = this.config.categoryOrder.split(",").map(s => s.trim())
+                    tracks.sort((a, b) => {
+                        if(order.indexOf(a.category) == -1 || order.indexOf(b.category) == -1) return 1;
+                        return order.indexOf(a.category) - order.indexOf(b.category);
+                    });
+                }
 
-                  thisB.addTracks( tracks, true );
+                this.addTracks( tracks, true );
 
-                  // hide the uncategorized pane if it is empty
-                  if( ! thisB.categories.Uncategorized.pane.containerNode.children.length ) {
-                      //thisB.removeChild( thisB.categories.Uncategorized.pane );
-                      thisB.categories.Uncategorized.pane.domNode.style.display = 'none';
-                  }
-              },
-              sort: sorter
-            });
+                // hide the uncategorized pane if it is empty
+                if( ! this.categories.Uncategorized.pane.containerNode.children.length ) {
+                    this.categories.Uncategorized.pane.domNode.style.display = 'none';
+                }
+            },
+            sort: sorter
+        });
     },
 
     addTracks: function( tracks, inStartup ) {

--- a/src/JBrowse/View/TrackList/Hierarchical.js
+++ b/src/JBrowse/View/TrackList/Hierarchical.js
@@ -99,7 +99,7 @@ return declare(
         }
 
         // add initally collapsed categories to the local storage
-        var arr = (this.get('collapsedCategories') || "").split(",");
+        var arr = (this.get('collapsedCategories') || "").split(",").map(s => s.trim()).map(s => s.split("/").map(s => s.trim()).join('/'));
         for(var i = 0; i < arr.length; i++) {
             lang.setObject('collapsed.' + arr[i], true, this.state);
         }
@@ -118,11 +118,16 @@ return declare(
                     categories: {}
                 };
                 if( this.config.categoryOrder ) {
-                    const order = this.config.categoryOrder.split(",").map(s => s.trim())
-                    var unordered = tracks.filter(t => order.indexOf(t.category) === -1);
-                    var ordered = tracks.filter(t => order.indexOf(t.category) !== -1);
+                    const order = this.config.categoryOrder.split(",").map(s => s.trim()).map(s => s.split("/").map(s => s.trim()).join('/'))
+                    tracks.forEach(t => {
+                        if(t.category) {
+                            t.cat = t.category.trim().split('/').map(s=>s.trim()).join('/')
+                        }
+                    })
+                    var unordered = tracks.filter(t => order.indexOf(t.cat) === -1);
+                    var ordered = tracks.filter(t => order.indexOf(t.cat) !== -1);
                     ordered.sort((a, b) => {
-                        return order.indexOf(a.category) - order.indexOf(b.category);
+                        return order.indexOf(a.cat) - order.indexOf(b.cat);
                     });
                     tracks = ordered.concat(unordered)
                 }

--- a/src/JBrowse/View/TrackList/Hierarchical.js
+++ b/src/JBrowse/View/TrackList/Hierarchical.js
@@ -95,6 +95,7 @@ return declare(
         ordered.sort((a, b) => {
             return order.indexOf(a.cat) - order.indexOf(b.cat);
         });
+        tracks.forEach(t => delete t.cat)
         return ordered.concat(unordered)
     },
 

--- a/tests/js_tests/main.js
+++ b/tests/js_tests/main.js
@@ -44,5 +44,6 @@ cjsRequire('./spec/SequenceTrack.spec.js')
 cjsRequire('./spec/VCF.spec.js')
 cjsRequire('./spec/BigBed.spec.js')
 cjsRequire('./spec/Hash.spec.js')
+cjsRequire('./spec/Hierarchical.spec.js')
 
 

--- a/tests/js_tests/spec/Hierarchical.spec.js
+++ b/tests/js_tests/spec/Hierarchical.spec.js
@@ -1,0 +1,38 @@
+require([
+    'dojo/aspect',
+    'dojo/_base/declare',
+    'JBrowse/View/TrackList/Hierarchical',
+],
+function(
+    aspect,
+    declare,
+    Hierarchical
+) {
+    describe( 'custom sort', function() {
+        var tracklist;
+        beforeEach( function() {
+            tracklist = new Hierarchical()
+        });
+
+        it( 'performs a custom sort', function() {
+            var tracks = [{
+                category: 't1'
+            }, {
+                category: 't2'
+            }, {
+                category: 't3'
+            }];
+            tracklist.induceCategoryOrder(tracks, 't1,t2,t3')
+
+
+            expect(tracks).toEqual([{
+                category: 't1'
+            }, {
+                category: 't2'
+            }, {
+                category: 't3'
+            }]);
+        });
+    });
+});
+

--- a/tests/js_tests/spec/Hierarchical.spec.js
+++ b/tests/js_tests/spec/Hierarchical.spec.js
@@ -1,18 +1,19 @@
 require([
     'dojo/aspect',
     'dojo/_base/declare',
+    'JBrowse/Browser',
     'JBrowse/View/TrackList/Hierarchical',
 ],
 function(
     aspect,
     declare,
+    Browser,
     Hierarchical
 ) {
-    describe( 'custom sort', function() {
-        var tracklist;
-        beforeEach( function() {
-            tracklist = new Hierarchical()
-        });
+    describe( 'Hierarchical.sort', function() {
+        var browser = new Browser({ unitTestMode: true })
+        browser.container = document.createElement('div')
+        var tracklist = new Hierarchical({ browser })
 
         it( 'performs a custom sort', function() {
             var tracks = [{
@@ -22,7 +23,7 @@ function(
             }, {
                 category: 't3'
             }];
-            tracklist.induceCategoryOrder(tracks, 't1,t2,t3')
+            tracks = tracklist.induceCategoryOrder(tracks, 't1,t2,t3')
 
 
             expect(tracks).toEqual([{
@@ -31,6 +32,64 @@ function(
                 category: 't2'
             }, {
                 category: 't3'
+            }]);
+        });
+        it( 'sorted explicitly', function() {
+            var tracks = [{
+                category: 't1'
+            }, {
+                category: 't2'
+            }, {
+                category: 't3'
+            }];
+            tracks = tracklist.induceCategoryOrder(tracks, 't3,t2,t1')
+
+
+            expect(tracks).toEqual([{
+                category: 't3'
+            }, {
+                category: 't2'
+            }, {
+                category: 't1'
+            }]);
+        });
+        it( 'partial sort', function() {
+            var tracks = [{
+                category: 't1'
+            }, {
+                category: 't2'
+            }, {
+                category: 't3'
+            }];
+            tracks = tracklist.induceCategoryOrder(tracks, 't3')
+
+
+            expect(tracks).toEqual([{
+                category: 't3'
+            }, {
+                category: 't1'
+            }, {
+                category: 't2'
+            }]);
+        });
+
+        it( 'subcategory', function() {
+            var tracks = [{
+                category: 't1/s1'
+            }, {
+                category: 't2'
+            }, {
+                category: 't3/s3'
+            }];
+            tracks = tracklist.induceCategoryOrder(tracks, 't3/s3,t2,t1 / s1')
+
+
+            expect(tracks).toEqual([{
+                category: 't3/s3'
+            }, {
+                category: 't2'
+            }, {
+                category: 't1/s1'
             }]);
         });
     });


### PR DESCRIPTION
This adds a `categoryOrder` configuration option to the tracklist. This is just a comma separated list of category names

So, if applied to volvox sample, you can specify

categoryOrder = VCF, Transcripts, Miscellaneous

This will sort these categories to the top. Small amount of code reformatting goes along with this PR but the core is just the track sorting :)