### PR TITLE
Add a static variable to check against adding the y-scale bar

### DIFF
--- a/src/JBrowse/View/Track/CanvasFeatures.js
+++ b/src/JBrowse/View/Track/CanvasFeatures.js
@@ -268,9 +268,11 @@ return declare(
                 if( renderArgs.showFeatures ) {
                     this.setLabel( this.key );
                     this.removeYScale();
+                    this.noYScale = true
                     this.fillFeatures( renderArgs );
                 }
                 else if( this.config.histograms.store || this.store.getRegionFeatureDensities ) {
+                    this.noYScale = false
                     this.fillHistograms( renderArgs );
                 }
                 else {
@@ -450,6 +452,9 @@ return declare(
     },
 
     _drawHistograms: function( viewArgs, histData ) {
+        if(this.noYScale) {
+            return
+        }
 
         var maxScore = 'max' in this.config.histograms ? this.config.histograms.max : histData.stats.max;
 

--- a/src/JBrowse/View/Track/CanvasFeatures.js
+++ b/src/JBrowse/View/Track/CanvasFeatures.js
@@ -456,7 +456,7 @@ return declare(
             return
         }
 
-        var maxScore = 'max' in this.config.histograms ? this.config.histograms.max : histData.stats.max;
+        var maxScore = 'max' in this.config.histograms ? this.config.histograms.max : (histData.stats||{}).max;
 
         // don't do anything if we don't know the score max
         if( maxScore === undefined ) {


### PR DESCRIPTION
This is a PR to address #1214 where the Y scale bar would be displayed over features. I think it is because the fillHistograms was async so it would be determined at some point to back out of showing histograms but the async would complete and show it (due to issues like #1190) 

This PR makes it explicit to not add the y-scale if it hits the async fillHistograms code after determining to not show them
