### PR TITLE
Hide sequence box configuration

### DIFF
--- a/docs/site/mouse_configs.md
+++ b/docs/site/mouse_configs.md
@@ -55,6 +55,8 @@ fmtDetailValue_Name = function(name, feature) {
 
 4. The ability to remove a field from the popup was added. You can do this by returning null from a fmtDetailField\_\* and fmtMetaField\_\* callback;
 
+5. In 1.15.4 the ability to remove the sequence FASTA boxes from the View details popups was added by specifying hideSequenceBox: true to the config
+
 # Customizing Left-click Behavior
 
 Beginning with JBrowse 1.5.0, the left-clicking behavior of feature tracks (both HTMLFeatures and CanvasFeatures) is highly configurable. To make something happen when left-clicking features on a track, add an onClick option to the feature track's configuration.

--- a/src/JBrowse/View/Track/_FeatureDetailMixin.js
+++ b/src/JBrowse/View/Track/_FeatureDetailMixin.js
@@ -77,7 +77,10 @@ return declare( FeatureDescriptionMixin, {
 
         this._renderAdditionalTagsDetail( track, f, featDiv, container );
 
-        this._renderUnderlyingReferenceSequence( track, f, featDiv, container );
+        if (!this.config.hideSequenceBox) {
+            this._renderUnderlyingReferenceSequence( track, f, featDiv, container );
+        }
+
 
         this._renderSubfeaturesDetail( track, f, featDiv, container, layer||1 );
 


### PR DESCRIPTION
This PR simply adds a hideSequenceBox config variable. There is not any additional options for this config e.g. only hiding the subfeatures sequences since #1211 says that featuresequence plugin is delegated for all other sequence displaying

