### PR TITLE
Make setup.sh use webpack production build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
 - RELEASE_VERSION=`node -e 'require("fs").readFile("src/JBrowse/package.json", (e,d)=>console.log(JSON.parse(d).version))'`
 - BUILD_DIR=$PWD
 - set -e
-- ./setup.sh
+- JBROWSE_BUILD_MIN=0 ./setup.sh
 - yarn lint
 - prove -Isrc/perl5 -r -j3 tests/perl_tests;
 - utils/jb_run.js -p 9000 & sleep 2

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+JBROWSE_BUILD_MIN=${JBROWSE_BUILD_MIN:=1}
 # check the exit status of the command, and print the last bit of the log if it fails
 done_message () {
     if [ $? == 0 ]; then
@@ -116,7 +117,7 @@ if [ -f "src/JBrowse/Browser.js" ]; then
         check_node
         [[ -f node_modules/.bin/yarn ]] || npm install yarn
         node_modules/.bin/yarn install
-        JBROWSE_BUILD_MIN=1 node_modules/.bin/yarn build
+        JBROWSE_BUILD_MIN=$JBROWSE_BUILD_MIN node_modules/.bin/yarn build
     ) >>setup.log 2>&1;
     done_message "" "" "FAILURE NOT ALLOWED"
 else

--- a/setup.sh
+++ b/setup.sh
@@ -116,7 +116,7 @@ if [ -f "src/JBrowse/Browser.js" ]; then
         check_node
         [[ -f node_modules/.bin/yarn ]] || npm install yarn
         node_modules/.bin/yarn install
-        node_modules/.bin/yarn build
+        JBROWSE_BUILD_MIN=1 node_modules/.bin/yarn build
     ) >>setup.log 2>&1;
     done_message "" "" "FAILURE NOT ALLOWED"
 else

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -122,7 +122,7 @@ if (DEBUG) {
     webpackConf.entry.run_jasmine = 'tests/js_tests/main.js'
     webpackConf.plugins.push( new webpack.optimize.AggressiveMergingPlugin() )
 } else {
-    webpackConf.plugins.push( new UglifyJsPlugin({ parallel: 4 }))
+    webpackConf.plugins.push( new UglifyJsPlugin())
 }
 
 module.exports = webpackConf


### PR DESCRIPTION
This PR makes running ./setup.sh use a production build. This can be turned off by setting an environment variable

    JBROWSE_BUILD_MIN=0 ./setup.sh

But by default you still just run ./setup.sh which is automatically a production build

Notes:

- The time difference for setup.sh for me with node modules already downloaded is 30 seconds for JBROWSE_BUILD_MIN=0 vs 90 seconds for JBROWSE_BUILD_MIN=1 (with 1 being the new default by this PR)
- I also disabled UglifyJsPlugin parallel because it was causing hanging under WSL (possible xref https://github.com/jupyterlab/jupyterlab/issues/4276) but removing it didn't modify build times for me

The payload of the initial page load is about 877kb vs 1.8Mb