### PR TITLE
embedded mode docs

### DIFF
--- a/docs/site/embedding.md
+++ b/docs/site/embedding.md
@@ -90,8 +90,28 @@ which looks like this
     </div>
   </div>
 </div>
-<script type="text/javascript" src="dist/main.bundle.js" charset="utf-8"></script>
+<script type="text/javascript" src="../dist/main.bundle.js" charset="utf-8"></script>
 
 The biggest gotcha with this embedding method is that the relative path from the page to
-the JBrowse `*.bundle.js` files must be `dist/`, so you might need to create a symbolic
-link, path alias, or similar construct.
+the JBrowse `*.bundle.js` files be `dist/` if you want to use a "stock" build of JBrowse.
+A simple way to accomplish that might be to configure a symlink in your site directory, for example by running `ln -s ../path/to/jbrowse/dist dist`, or by creating some kind of path alias in your web server configuration.
+
+The other option is to clone JBrowse from GitHub and run `setup.sh` with a nonstandard `JBROWSE_PUBLIC_PATH` environment variable set, which will configure JBrowse to serve its bundles from a different path. For example, if you wanted to lay out a site like:
+
+```generic
+site_root
+  |- docs
+      |-  index.html (runs embedded jbrowse)
+  |- jbrowse (jbrowse installation)
+```
+
+you might run the following shell commands:
+
+```sh
+cd site_root
+git clone https://github.com/GMOD/jbrowse.git
+cd jbrowse
+JBROWSE_PUBLIC_PATH=/jbrowse/dist/ ./setup.sh
+```
+
+Note the trailing slash on the value of `JBROWSE_PUBLIC_PATH`!

--- a/docs/site/embedding.md
+++ b/docs/site/embedding.md
@@ -50,7 +50,9 @@ and `overview=0` hides the overview scale bar.
 
 ## Embedding directly in a `div`
 
-A more flexible way to embed JBrowse is by embedding it directly in a `div` in the parent document.
+JBrowse 1.14.0 and higher supports a more flexible way of embedding JBrowse by running it directly in a `div` inside another document.
+
+Example code for this:
 
 ```html
 <html>
@@ -80,7 +82,7 @@ A more flexible way to embed JBrowse is by embedding it directly in a `div` in t
 </html>
 ```
 
-which looks like this
+which looks like this when run
 
 <div style="padding: 0 1em; margin: 1em 0; border: 1px solid black">
   <h1>Lorem ipsum</h1>
@@ -92,13 +94,11 @@ which looks like this
 </div>
 <script type="text/javascript" src="../dist/main.bundle.js" charset="utf-8"></script>
 
-The biggest gotcha with this embedding method is that the relative path from the page to
-the JBrowse `*.bundle.js` files be `dist/` if you want to use a "stock" build of JBrowse.
-A simple way to accomplish that might be to configure a symlink in your site directory, for example by running `ln -s ../path/to/jbrowse/dist dist`, or by creating some kind of path alias in your web server configuration.
+The biggest gotcha with this embedding method is that the relative path from the page where you embed JBrowse to the JBrowse `*.bundle.js` files must be `dist/` if you want to use a "stock" build of JBrowse. A simple way to accomplish that might be to configure a symlink in your site directory, for example by running `ln -s  ./path/to/jbrowse/dist dist`, or by creating some kind of path alias in your web server configuration.
 
-The other option is to clone JBrowse from GitHub and run `setup.sh` with a nonstandard `JBROWSE_PUBLIC_PATH` environment variable set, which will configure JBrowse to serve its bundles from a different path. For example, if you wanted to lay out a site like:
+For JBrowse 1.15.5 or higher, the other option is to clone JBrowse from GitHub and run `setup.sh` with a nonstandard `JBROWSE_PUBLIC_PATH` environment variable set, which will configure JBrowse to serve its bundles from a different path. For example, if you had this site layout:
 
-```generic
+```text
 site_root
   |- docs
       |-  index.html (runs embedded jbrowse)
@@ -114,4 +114,4 @@ cd jbrowse
 JBROWSE_PUBLIC_PATH=/jbrowse/dist/ ./setup.sh
 ```
 
-Note the trailing slash on the value of `JBROWSE_PUBLIC_PATH`!
+Note the trailing slash on the value of JBROWSE_PUBLIC_PATH.

--- a/docs/site/embedding.md
+++ b/docs/site/embedding.md
@@ -1,0 +1,97 @@
+---
+id: embedding
+title: Embedding JBrowse
+---
+
+## Embedding in an iframe
+
+One way of embedding JBrowse just runs the full browser in an `iframe` element.  It's very simple and easy to get running.
+
+```html
+<html>
+  <head>
+    <title>JBrowse Embedded</title>
+  </head>
+  <body>
+    <h1>Embedded Volvox JBrowse</h1>
+    <div style="width: 400px; margin: 0 auto;">
+      <iframe
+        src="../../index.html?data=sample_data/json/volvox&tracklist=0&nav=0&overview=0&tracks=DNA%2CExampleFeatures%2CNameTest%2CMotifs%2CAlignments%2CGenes%2CReadingFrame%2CCDS%2CTranscript%2CClones%2CEST"
+        style="border: 1px solid black"
+        width="300"
+        height="300"
+        >
+      </iframe>
+    </div>
+  </body>
+</html>
+```
+
+Which ends up looking like this:
+
+<!-- <div style="padding: 0 1em; margin: 1em 0; border: 1px solid black">
+    <h1>Embedded Volvox JBrowse</h1>
+    <div style="width: 400px; margin: 0 auto;">
+        <iframe
+            src="https://jbrowse.org/code/latest-release/index.html?data=sample_data/json/volvox&tracklist=0&nav=0&overview=0&tracks=DNA%2CExampleFeatures%2CNameTest%2CMotifs%2CAlignments%2CGenes%2CReadingFrame%2CCDS%2CTranscript%2CClones%2CEST"
+            style="border: 1px solid black"
+            width="300"
+            height="300"
+            >
+        </iframe>
+    </div>
+</div> -->
+
+Note that the iframe's `src` attribute just points to the same JBrowse URL as your browser would.
+However, it sets a few additional options in the URL to hide some of the UI elements to give
+the view a more "embedded" feel: `tracklist=0` hides the track list on the left side,
+`nav=0` hides the navigation bar (the zoom buttons, search box, etc),
+and `overview=0` hides the overview scale bar.
+
+## Embedding directly in a `div`
+
+A more flexible way to embed JBrowse is by embedding it directly in a `div` in the parent document.
+
+```html
+<html>
+
+<head>
+  <title>Lorem ipsum</title>
+  <script type="text/javascript" src="dist/main.bundle.js" charset="utf-8"></script>
+  <style>
+    body {
+      background: blue;
+      color: white
+    }
+
+    .jbrowse {
+      height: 600px;
+      width: 900px;
+      padding: 0;
+      margin-left: 5em;
+      border: 1px solid #ccc
+    }
+  </style>
+</head>
+
+<body>
+</body>
+
+</html>
+```
+
+which looks like this
+
+<div style="padding: 0 1em; margin: 1em 0; border: 1px solid black">
+  <h1>Lorem ipsum</h1>
+  <div class="jbrowse"  id="GenomeBrowser" data-config='"baseUrl": "../", "dataRoot": "../sample_data/json/volvox"'>
+    <div class="LoadingScreen" style="padding: 50px;">
+      <h1>Loading...</h1>
+    </div>
+  </div>
+</div>
+<script type="text/javascript" src="dist/main.bundle.js" charset="utf-8"></script>
+
+The biggest gotcha with this embedding method is that the relative path from the page to
+the JBrowse `*.bundle.js` files must be `dist/`, so you might need to create a symbolic
+link, path alias, or similar construct.

--- a/docs/site/embedding.md
+++ b/docs/site/embedding.md
@@ -109,7 +109,7 @@ you might run the following shell commands:
 
 ```sh
 cd site_root
-git clone https://github.com/GMOD/jbrowse.git
+git clone --depth 50 https://github.com/GMOD/jbrowse.git
 cd jbrowse
 JBROWSE_PUBLIC_PATH=/jbrowse/dist/ ./setup.sh
 ```

--- a/release-notes.md
+++ b/release-notes.md
@@ -10,6 +10,9 @@
    Thanks to @rbuels and others for testing and feedback (pull #1215, issue #1178,
    @cmdcolin)
 
+ * setup.sh now supports setting a `JBROWSE_PUBLIC_PATH` environment variable for
+   more flexibility in iframeless embedding scenarios (issue #1213, @rbuels)
+
 # Release 1.15.4     2018-10-05 13:02:55 UTC
 
 ## Minor improvements

--- a/tests/iframeless-embed.html
+++ b/tests/iframeless-embed.html
@@ -21,7 +21,7 @@
 
 <body>
   <h1>Lorem ipsum</h1>
-  <div class="jbrowse" data-config='"baseUrl": "../", "dataRoot": "../sample_data/json/volvox"' id="GenomeBrowser">
+  <div class="jbrowse" id="GenomeBrowser" data-config='"baseUrl": "../", "dataRoot": "../sample_data/json/volvox"'>
     <div class="LoadingScreen" style="padding: 50px;">
       <h1>Loading...</h1>
     </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,17 +14,6 @@ const webpack = require("webpack")
 // and forego generating source maps
 const DEBUG = ! [1,'1','true'].includes(process.env.JBROWSE_BUILD_MIN)
 
-const AUTOPREFIXER_BROWSERS = [
-    'Android 2.3',
-    'Android >= 4',
-    'Chrome >= 35',
-    'Firefox >= 31',
-    'Explorer >= 9',
-    'iOS >= 7',
-    'Opera >= 12',
-    'Safari >= 7.1',
-  ];
-
 var webpackConf = {
     entry: {
         main: "src/JBrowse/main",
@@ -107,7 +96,7 @@ var webpackConf = {
         filename: '[name].bundle.js',
         chunkFilename: '[name].bundle.js',
         path: path.resolve(__dirname, 'dist'),
-        publicPath: 'dist/'
+        publicPath: process.env.JBROWSE_PUBLIC_PATH || 'dist/'
     },
     resolveLoader: {
         modules: ["node_modules"]

--- a/website/deploy.sh
+++ b/website/deploy.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
+if [ ! -r package.json ]; then
+    echo cannot read version number from ./package.json, aborting website deploy;
+    exit 1;
+fi;
+RELEASE_VERSION=`node -e 'require("fs").readFile("package.json", (e,d)=>console.log(JSON.parse(d).version))'`
 set -e
+set -x
 cd ${0%/*}
 yarn
 yarn build
+ln -sf ../code/JBrowse-$RELEASE_VERSION/dist build/jbrowse/docs/dist
 openssl aes-256-cbc -K $encrypted_a33f2fb5219d_key -iv $encrypted_a33f2fb5219d_iv -in deploy.pem.enc -out deploy.pem -d
 chmod 600 deploy.pem
 rsync -r -e "ssh -i deploy.pem -o StrictHostKeyChecking=no" build/jbrowse/ jbrowse_docs@jbrowse.org:/var/www/site

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -14,6 +14,7 @@
       "variants"
     ],
     "Advanced configuration": [
+      "embedding",
       "mouse_configs",
       "configuration_file_formats",
       "dataset_selector",


### PR DESCRIPTION
Adds some docs about iframe and iframeless embedding.  Also adds support for JBROWSE_PUBLIC_PATH, which I discovered was kind of needed to make docs that are satisfactory. ;-)

fixes #1213 