### PR TITLE
Avoid issue where Range can have max less than min

### DIFF
--- a/src/JBrowse/Store/SeqFeature/BigWig/RequestWorker.js
+++ b/src/JBrowse/Store/SeqFeature/BigWig/RequestWorker.js
@@ -133,7 +133,7 @@ var RequestWorker = declare( null,
         var maxCirBlockSpan = 4 +  (this.window.cirBlockSize * 32);   // Upper bound on size, based on a completely full leaf node.
         var spans;
         for (var i = 0; i < offset.length; ++i) {
-            var blockSpan = new Range(offset[i], Math.min(offset[i] + maxCirBlockSpan, this.window.cirTreeOffset + this.window.cirTreeLength));
+            var blockSpan = new Range(offset[i], offset[i] + maxCirBlockSpan);
             spans = spans ? spans.union( blockSpan ) : blockSpan;
         }
 


### PR DESCRIPTION
This is a PR to address #1226 which found a certain bigbed file that was not able to be loaded natively. I found that essentially a "Range" object was created where max less than the min, and then no action was taken in a specific for loop.

I found that I could modify a Range object creation to remove this particular "Math.min" operation to fix this issue. It's not exactly clear what purpose this had but removing it didn't seem to cause any issue on BigBed or BigWig files I tested. There is also no similar Math.min type operation in the dalliance codebase for BigWig from what I could tell