### PR TITLE
Add unprocessed transcript glyph

### DIFF
--- a/docs/site/config_canvas_features.md
+++ b/docs/site/config_canvas_features.md
@@ -55,6 +55,8 @@ Introduced in JBrowse 1.10.0, the new JBrowse CanvasFeatures tracks are faster a
 |`topLevelFeatures`|Specifies which feature types should be considered "top-level" for this track. For example, if you have a track with gene-\>mRNA-\>CDS features, but for some reason want to only display the mRNA features, you can set topLevelFeatures=mRNA. Can also be an array of string types, or a function callback that returns an array of types. Default: all features are displayed. Added in 1.14.0|
 |`topLevelFeaturesPercent`|Approximate percentage of features in the store that are top-level. Used to correct feature statistics estimates, which are used by JBrowse to decide when to display feature labels, and when to show feature density histograms. For example, topLevelFeaturesPercent=10 would say that only about 10% of features in the store are top-level, so adjust statistics estimates accordingly. Default 100, adding in 1.15.4.|
 |`ItemRgb`|If set to true, the RGB colors specified in BigBed or BED files will be used for the feature's background color. Default true. Added in 1.14.0|
+|`style→unprocessedTranscriptColor`|A color for the unprocessed transcript glyph. This is used when there is a mix of coding and non-coding transcripts in your GFF|
+|`noncodingType`|An array of non-coding feature types from column 3 of your GFF, default: ['ncRNA', 'lnc_RNA', 'lncRNA', 'miRNA']|
 
 Note: the "compact" displayMode for CanvasFeatures tracks uses style-\>height and multiplies it by 0.35 to create the compact view. Therefore, if you adjust style-\>height to a smaller default value, then you can create "ultra compact" visualizations.
 

--- a/src/JBrowse/View/FeatureGlyph/Gene.js
+++ b/src/JBrowse/View/FeatureGlyph/Gene.js
@@ -22,7 +22,7 @@ _defaultConfig: function() {
         this.inherited(arguments),
         {
             transcriptType: 'mRNA',
-            noncodingType: ['ncRNA','transcript', 'lnc_RNA', 'lncRNA'],
+            noncodingType: ['ncRNA','transcript', 'lnc_RNA', 'lncRNA', 'miRNA'],
             style: {
                 transcriptLabelFont: 'normal 10px Univers,Helvetica,Arial,sans-serif',
                 transcriptLabelColor: 'black',

--- a/src/JBrowse/View/FeatureGlyph/Gene.js
+++ b/src/JBrowse/View/FeatureGlyph/Gene.js
@@ -3,6 +3,7 @@ define([
            'dojo/_base/lang',
            'dojo/_base/array',
            'JBrowse/View/FeatureGlyph/Box',
+           'JBrowse/View/FeatureGlyph/UnprocessedTranscript',
            'JBrowse/View/FeatureGlyph/ProcessedTranscript'
        ],
        function(
@@ -10,6 +11,7 @@ define([
            lang,
            array,
            BoxGlyph,
+           UnprocessedTranscript,
            ProcessedTranscriptGlyph
        ) {
 
@@ -20,6 +22,7 @@ _defaultConfig: function() {
         this.inherited(arguments),
         {
             transcriptType: 'mRNA',
+            noncodingType: ['ncRNA','transcript', 'lnc_RNA', 'lncRNA'],
             style: {
                 transcriptLabelFont: 'normal 10px Univers,Helvetica,Arial,sans-serif',
                 transcriptLabelColor: 'black',
@@ -32,6 +35,9 @@ _defaultConfig: function() {
 
 _boxGlyph: function() {
     return this.__boxGlyph || ( this.__boxGlyph = new BoxGlyph({ track: this.track, browser: this.browser, config: this.config }) );
+},
+_ntGlyph: function() {
+    return this.__ntGlyph || ( this.__ntGlyph = new UnprocessedTranscript({ track: this.track, browser: this.browser, config: this.config }) );
 },
 _ptGlyph: function() {
     return this.__ptGlyph || ( this.__ptGlyph = new ProcessedTranscriptGlyph({ track: this.track, browser: this.browser, config: this.config }) );
@@ -67,10 +73,11 @@ _getFeatureRectangle( viewArgs, feature ) {
         fRect.r = -Infinity;
 
         var transcriptType = this.getConfForFeature( 'transcriptType', feature );
+        var noncodingType = this.getConfForFeature( 'noncodingType', feature );
         for( var i = 0; i < subfeatures.length; i++ ) {
             var subRect = ( subfeatures[i].get('type') == transcriptType
                             ? this._ptGlyph()
-                            : this._boxGlyph()
+                            : (noncodingType.includes(subfeatures[i].get('type')) ?  this._ntGlyph() : this._boxGlyph())
                           )._getFeatureRectangle( subArgs, subfeatures[i] );
 
             padding = i == subfeatures.length-1 ? 0 : 1;

--- a/src/JBrowse/View/FeatureGlyph/Gene.js
+++ b/src/JBrowse/View/FeatureGlyph/Gene.js
@@ -22,7 +22,7 @@ _defaultConfig: function() {
         this.inherited(arguments),
         {
             transcriptType: 'mRNA',
-            noncodingType: ['ncRNA','transcript', 'lnc_RNA', 'lncRNA', 'miRNA'],
+            noncodingType: ['ncRNA', 'lnc_RNA', 'lncRNA', 'miRNA'],
             style: {
                 transcriptLabelFont: 'normal 10px Univers,Helvetica,Arial,sans-serif',
                 transcriptLabelColor: 'black',

--- a/src/JBrowse/View/FeatureGlyph/UnprocessedTranscript.js
+++ b/src/JBrowse/View/FeatureGlyph/UnprocessedTranscript.js
@@ -1,0 +1,30 @@
+define([
+           'dojo/_base/declare',
+           'dojo/_base/Color',
+           'JBrowse/View/FeatureGlyph/Segments'
+       ],
+       function(
+           declare,
+           Color,
+           Segments
+       ) {
+
+return declare( Segments, {
+    _defaultConfig: function() {
+        return this._mergeConfigs(this.inherited(arguments), {
+            style: {
+                unprocessedTranscriptColor: 'red'
+            }
+        });
+    },
+    renderBox: function( context, viewInfo, feature, top, overallHeight, parentFeature, style ) {
+        style = style || lang.hitch( this, 'getStyle' );
+        return this.inherited(arguments, [context, viewInfo, feature, top, overallHeight, parentFeature, function(feat, attr) {
+            if(attr == 'color')
+                return style(parentFeature, 'unprocessedTranscriptColor')
+            return style(feat, attr)
+        }])
+    }
+
+});
+});

--- a/src/JBrowse/View/FeatureGlyph/UnprocessedTranscript.js
+++ b/src/JBrowse/View/FeatureGlyph/UnprocessedTranscript.js
@@ -1,11 +1,11 @@
 define([
            'dojo/_base/declare',
-           'dojo/_base/Color',
+           'dojo/_base/lang',
            'JBrowse/View/FeatureGlyph/Segments'
        ],
        function(
            declare,
-           Color,
+           lang,
            Segments
        ) {
 

--- a/src/JBrowse/View/Track/CanvasFeatures.js
+++ b/src/JBrowse/View/Track/CanvasFeatures.js
@@ -212,7 +212,10 @@ return declare(
         let guess = {
             'gene': 'Gene',
             'mRNA': 'ProcessedTranscript',
-            'transcript': 'ProcessedTranscript'
+            'ncRNA': 'UnprocessedTranscript',
+            'lncRNA': 'UnprocessedTranscript',
+            'lnc_RNA': 'UnprocessedTranscript',
+            'miRNA': 'UnprocessedTranscript'
         }[feature.get('type')]
 
         // otherwise, make it Segments if it has children,

--- a/src/JBrowse/View/Track/CanvasFeatures.js
+++ b/src/JBrowse/View/Track/CanvasFeatures.js
@@ -212,6 +212,7 @@ return declare(
         let guess = {
             'gene': 'Gene',
             'mRNA': 'ProcessedTranscript',
+            'transcript': 'ProcessedTranscript',
             'ncRNA': 'UnprocessedTranscript',
             'lncRNA': 'UnprocessedTranscript',
             'lnc_RNA': 'UnprocessedTranscript',


### PR DESCRIPTION
This adds an "unprocessed transcript" glyph with an `unprocessedTranscriptColor` config variable that distinguishes it from the other transcripts

This code uses the  `noncodingType` config (analogous to `transcriptType`) to render non-coding features with a gene parent correctly


![screenshot-localhost-2018 10 08-15-37-38](https://user-images.githubusercontent.com/6511937/46629819-224a2580-cb10-11e8-914a-0e37308e8ba9.png)

This references #1106 although it's not a true pseudogene glyph, it handles unprocessed transcripts like ncRNA, lncRNA, miRNA, etc. Issues like #757 are potentially also relevant but was closed with a workaround