### PR TITLE
Fix for embedded minified builds

### DIFF
--- a/build/dojo-loader-config.js
+++ b/build/dojo-loader-config.js
@@ -4,20 +4,20 @@ const {findPlugins} = require('./plugin-util')
 module.exports = function(env) {
 
     dojoConfig = {
-		baseUrl: '.',
-		packages: [
-			{
-				name: 'dojo',
-				location: env.dojoRoot + '/dojo',
-			},
-			{
-				name: 'dijit',
-				location: env.dojoRoot + '/dijit',
-			},
-			{
-				name: 'dojox',
-				location: env.dojoRoot + '/dojox',
-			},
+        baseUrl: '.',
+        packages: [
+            {
+                name: 'dojo',
+                location: env.dojoRoot + 'dojo',
+            },
+            {
+                name: 'dijit',
+                location: env.dojoRoot + 'dijit',
+            },
+            {
+                name: 'dojox',
+                location: env.dojoRoot + 'dojox',
+            },
             {
                 name: 'JBrowse',
                 location: 'src/JBrowse',
@@ -25,22 +25,22 @@ module.exports = function(env) {
             },
             {
                 name: 'dgrid',
-                location: env.dojoRoot + '/dgrid',
+                location: env.dojoRoot + 'dgrid',
                 lib: '.'
             },
             {
                 name: 'dstore',
-                location: env.dojoRoot + '/dojo-dstore',
+                location: env.dojoRoot + 'dojo-dstore',
                 lib: '.'
             },
             {
                 name: 'jszlib',
-                location: env.dojoRoot + '/jszlib',
+                location: env.dojoRoot + 'jszlib',
                 lib: '.'
             },
             {
                 name: 'FileSaver',
-                location: env.dojoRoot + '/filesaver.js',
+                location: env.dojoRoot + 'filesaver.js',
                 lib: '.'
             }
         ]
@@ -49,7 +49,7 @@ module.exports = function(env) {
         )
         ,
 
-		async: true
+        async: true
     }
 
     return dojoConfig

--- a/build/glob-loader.js
+++ b/build/glob-loader.js
@@ -6,6 +6,7 @@ const {findPlugins} = require('./plugin-util')
 const blacklist = {};
 `
 JBrowse/main
+JBrowse/standalone
 `
 .trim().split(/\s+/).forEach(mid => blacklist[mid] = 1)
 
@@ -59,7 +60,7 @@ module.exports = function(content,map,meta) {
                 let code =
                     format === 'CommonJS' ? `${blacklisted}var __webpackRequireGlob${i} = require('./${mid}') // ${mid}` :
                                             `${blacklisted} '${mid}',`
-                //console.log(code)
+                // console.log(code)
                 return code
             }).join('\n')
         }

--- a/src/JBrowse/main.js
+++ b/src/JBrowse/main.js
@@ -18,7 +18,6 @@ function (
     QueryParamConfigMapper,
     ioQuery,
     JSON,
-    conf
 ) {
     // the initial configuration of this JBrowse
     // instance

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,10 +25,10 @@ var webpackConf = {
         new DojoWebpackPlugin({
             loaderConfig: require("./build/dojo-loader-config"),
             environment: {
-                dojoRoot: "./dist"
+                dojoRoot: process.env.JBROWSE_PUBLIC_PATH || "./dist/"
             },
             buildEnvironment: {
-                dojoRoot: "node_modules"
+                dojoRoot: "node_modules/"
             },
             locales: ["en"],
             loader: path.resolve('./build/dojo-webpack-plugin-loader/dojo/dojo.js')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,7 +69,7 @@ var webpackConf = {
                 }
             },
             {
-                test: /src\/JBrowse\/main.js|tests\/js_tests\/main.js/,
+                test: /src\/JBrowse\/main.js|src\/JBrowse\/standalone.js|tests\/js_tests\/main.js/,
                 use: [{ loader: path.resolve('build/glob-loader.js') }]
             },
             {


### PR DESCRIPTION
Add `standalone.js` to the list of files that `glob-loader.js` looks for. Also includes a fix so JBrowse doesn't complain about not being able to find `empty.gif` when JBROWSE_PUBLIC_PATH is overridden.

Resolves #1238