### PR TITLE
Add more embedding info to docs

### DIFF
--- a/docs/site/embedding.md
+++ b/docs/site/embedding.md
@@ -87,7 +87,8 @@ Example code for this:
         "show_nav": false,
         "show_tracklist": false,
         "show_overview": false,
-        "update_browser_title": false
+        "update_browser_title": false,
+        "updateBrowserURL": false
       '
     >
       <div id="LoadingScreen" style="padding: 50px;">
@@ -114,7 +115,8 @@ which looks like this when run
       "show_nav": false,
       "show_tracklist": false,
       "show_overview": false,
-      "update_browser_title": false
+      "update_browser_title": false,
+      "updateBrowserURL": false
     '
     style="height: 300px;width: 600px;padding: 0;margin-left: 5em;border: 1px solid #ccc"
   >

--- a/docs/site/embedding.md
+++ b/docs/site/embedding.md
@@ -10,15 +10,15 @@ One way of embedding JBrowse just runs the full browser in an `iframe` element. 
 ```html
 <html>
   <head>
-    <title>JBrowse Embedded</title>
+    <title>Embedded JBrowse</title>
   </head>
   <body>
-    <h1>Embedded Volvox JBrowse</h1>
-    <div style="width: 400px; margin: 0 auto;">
+    <h1>Volvox JBrowse Embedded in an <code>iframe</code></h1>
+    <div style="width: 600px; margin: 0 auto;">
       <iframe
         src="../../index.html?data=sample_data/json/volvox&tracklist=0&nav=0&overview=0&tracks=DNA%2CExampleFeatures%2CNameTest%2CMotifs%2CAlignments%2CGenes%2CReadingFrame%2CCDS%2CTranscript%2CClones%2CEST"
         style="border: 1px solid black"
-        width="300"
+        width="600"
         height="300"
         >
       </iframe>
@@ -29,18 +29,18 @@ One way of embedding JBrowse just runs the full browser in an `iframe` element. 
 
 Which ends up looking like this:
 
-<!-- <div style="padding: 0 1em; margin: 1em 0; border: 1px solid black">
-    <h1>Embedded Volvox JBrowse</h1>
-    <div style="width: 400px; margin: 0 auto;">
+<div style="padding: 0 1em; margin: 1em 0; border: 1px solid black">
+    <h1>Volvox JBrowse Embedded in an <code>iframe</code></h1>
+    <div style="width: 600px; margin: 0 auto;">
         <iframe
-            src="https://jbrowse.org/code/latest-release/index.html?data=sample_data/json/volvox&tracklist=0&nav=0&overview=0&tracks=DNA%2CExampleFeatures%2CNameTest%2CMotifs%2CAlignments%2CGenes%2CReadingFrame%2CCDS%2CTranscript%2CClones%2CEST"
+            src="../code/latest-release/?data=sample_data/json/volvox&tracklist=0&nav=0&overview=0&tracks=DNA%2CExampleFeatures%2CNameTest%2CMotifs%2CAlignments%2CGenes%2CReadingFrame%2CCDS%2CTranscript%2CClones%2CEST"
             style="border: 1px solid black"
-            width="300"
+            width="600"
             height="300"
             >
         </iframe>
     </div>
-</div> -->
+</div>
 
 Note that the iframe's `src` attribute just points to the same JBrowse URL as your browser would.
 However, it sets a few additional options in the URL to hide some of the UI elements to give
@@ -58,8 +58,7 @@ Example code for this:
 <html>
 
 <head>
-  <title>Lorem ipsum</title>
-  <script type="text/javascript" src="dist/main.bundle.js" charset="utf-8"></script>
+  <title>Embedded JBrowse</title>
   <style>
     body {
       background: blue;
@@ -67,8 +66,8 @@ Example code for this:
     }
 
     .jbrowse {
-      height: 600px;
-      width: 900px;
+      height: 300px;
+      width: 600px;
       padding: 0;
       margin-left: 5em;
       border: 1px solid #ccc
@@ -77,6 +76,26 @@ Example code for this:
 </head>
 
 <body>
+  <div style="padding: 0 1em; margin: 1em 0; border: 1px solid black">
+    <h1>Volvox JBrowse Embedded in a <code>div</code></h1>
+    <div
+      class="jbrowse"
+      id="GenomeBrowser"
+      data-config='
+        "baseUrl": "../",
+        "dataRoot": "sample_data/json/volvox",
+        "show_nav": false,
+        "show_tracklist": false,
+        "show_overview": false,
+        "update_browser_title": false
+      '
+    >
+      <div class="LoadingScreen" style="padding: 50px;">
+        <h1>Loading...</h1>
+      </div>
+    </div>
+  </div>
+  <script type="text/javascript" src="../dist/main.bundle.js" charset="utf-8"></script>
 </body>
 
 </html>
@@ -84,15 +103,27 @@ Example code for this:
 
 which looks like this when run
 
-<div style="padding: 0 1em; margin: 1em 0; border: 1px solid black">
-  <h1>Lorem ipsum</h1>
-  <div class="jbrowse"  id="GenomeBrowser" data-config='"baseUrl": "../", "dataRoot": "../sample_data/json/volvox"'>
+<div style="padding: 0 1em; margin: 1em 0; border: 1px solid black; background: blue; color: white">
+  <h1>Volvox JBrowse Embedded in a <code>div</code></h1>
+  <div
+    class="jbrowse"
+    id="GenomeBrowser"
+    data-config='
+      "baseUrl": "../code/latest-release/",
+      "dataRoot": "sample_data/json/volvox",
+      "show_nav": false,
+      "show_tracklist": false,
+      "show_overview": false,
+      "update_browser_title": false
+    '
+    style="height: 300px;width: 600px;padding: 0;margin-left: 5em;border: 1px solid #ccc"
+  >
     <div class="LoadingScreen" style="padding: 50px;">
       <h1>Loading...</h1>
     </div>
   </div>
 </div>
-<script type="text/javascript" src="../dist/main.bundle.js" charset="utf-8"></script>
+<script type="text/javascript" src="../code/latest-release/dist/main.bundle.js" charset="utf-8"></script>
 
 The biggest gotcha with this embedding method is that the relative path from the page where you embed JBrowse to the JBrowse `*.bundle.js` files must be `dist/` if you want to use a "stock" build of JBrowse. A simple way to accomplish that might be to configure a symlink in your site directory, for example by running `ln -s  ./path/to/jbrowse/dist dist`, or by creating some kind of path alias in your web server configuration.
 
@@ -115,3 +146,74 @@ JBROWSE_PUBLIC_PATH=/jbrowse/dist/ ./setup.sh
 ```
 
 Note the trailing slash on the value of JBROWSE_PUBLIC_PATH.
+
+## Embedding in a `div` with dynamic configs
+
+JBrowse also allows you to define your own config dynamically and create an embedded JBrowse with that config. To do this, you first run `browser.bundle.js` which makes available `window.Browser`. You can then us that with a config object to create a JBrowse instace. This can be useful for, for example, creating a JBrowse track from data you already have in memory via the FromConfig store class.
+
+This could look like this:
+
+```html
+<head>
+  <title>Embedded JBrowse</title>
+  <style>
+    body {
+      background: blue;
+      color: white
+    }
+
+    .jbrowse {
+      height: 300px;
+      width: 600px;
+      padding: 0;
+      margin-left: 5em;
+      border: 1px solid #ccc
+    }
+  </style>
+</head>
+
+<body>
+  <div style="padding: 0 1em; margin: 1em 0; border: 1px solid black">
+    <h1>Custom JBrowse Embedded in a <code>div</code></h1>
+    <div class="jbrowse" id="GenomeBrowser">
+      <div class="LoadingScreen" style="padding: 50px;">
+        <h1>Loading...</h1>
+      </div>
+    </div>
+  </div>
+  
+  <script type="text/javascript" src="../dist/browser.bundle.js" charset="utf-8"></script>
+  <script>
+    var features = []
+    // Add some features
+    var config = {
+      containerID: 'GenomeBrowser',
+      baseUrl: '../',
+      refSeqs: {
+        url: 'https://s3.amazonaws.com/1000genomes/technical/reference/GRCh38_reference_genome/GRCh38_full_analysis_set_plus_decoy_hla.fa.fai',
+      },
+      tracks: [
+        {
+          key: 'GRCH38 Reference Sequence',
+          label: 'GRCH38 Reference Sequence',
+          urlTemplate: 'https://s3.amazonaws.com/1000genomes/technical/reference/GRCh38_reference_genome/GRCh38_full_analysis_set_plus_decoy_hla.fa'
+        },
+        {
+          key: 'MyTrack',
+          label: 'MyTrack',
+          storeClass: 'JBrowse/Store/SeqFeature/FromConfig',
+          features: features,
+          type: 'CanvasVariants'
+        }
+      ]
+    };
+
+    // Add to the config or tracks
+
+    // Instantiate JBrowse
+    window.addEventListener('load', () => {
+      window.JBrowse = new window.Browser( config );
+    })
+  </script>
+</body>
+```

--- a/docs/site/embedding.md
+++ b/docs/site/embedding.md
@@ -90,7 +90,7 @@ Example code for this:
         "update_browser_title": false
       '
     >
-      <div class="LoadingScreen" style="padding: 50px;">
+      <div id="LoadingScreen" style="padding: 50px;">
         <h1>Loading...</h1>
       </div>
     </div>
@@ -118,7 +118,7 @@ which looks like this when run
     '
     style="height: 300px;width: 600px;padding: 0;margin-left: 5em;border: 1px solid #ccc"
   >
-    <div class="LoadingScreen" style="padding: 50px;">
+    <div id="LoadingScreen" style="padding: 50px;">
       <h1>Loading...</h1>
     </div>
   </div>
@@ -176,7 +176,7 @@ This could look like this:
   <div style="padding: 0 1em; margin: 1em 0; border: 1px solid black">
     <h1>Custom JBrowse Embedded in a <code>div</code></h1>
     <div class="jbrowse" id="GenomeBrowser">
-      <div class="LoadingScreen" style="padding: 50px;">
+      <div id="LoadingScreen" style="padding: 50px;">
         <h1>Loading...</h1>
       </div>
     </div>

--- a/release-notes.md
+++ b/release-notes.md
@@ -23,6 +23,10 @@
  * Fix parsing of certain bigBed files that were hanging on track startup
    (issue #1226, pull #1229, @cmdcolin)
 
+ * Added documentation on embedding JBrowse in an iframe and in a div, including
+   how to embed JBrowse using a custom JavaScript object as a configuration
+   (pull #1228, pull #1243, @rbuels and @garrettjstevens)
+
 ## Bug fixes
 
  * Fixed issue with getting feature density from BAM files via the index stats
@@ -30,6 +34,10 @@
 
  * Fixed issue where some feature mouseovers where not working properly (issue
    #1236, @cmdcolin)
+
+ * Fixed issue where instantiating JBrowse via `standalone.js` didn't work when
+   in a production build with JBROWSE_PUBLIC_PATH overridden (issue #1239,
+   @garrettjstevens)
 
 # Release 1.15.4     2018-10-05 13:02:55 UTC
 

--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -2197,6 +2197,7 @@ _configDefaults: function() {
         show_overview: true,
         show_fullviewlink: true,
         update_browser_title: true,
+        updateBrowserURL: true,
 
         refSeqs: "{dataRoot}/seq/refSeqs.json",
         include: [

--- a/src/JBrowse/main.js
+++ b/src/JBrowse/main.js
@@ -61,7 +61,6 @@ function (
 
             return browser.makeCurrentViewURL({ nav: 1, tracklist: 1, overview: 1 });
         },
-        updateBrowserURL: true,
         electronData: queryParams.electronData || (Util.isElectron() && electronRequire('electron').remote.app.getPath('userData'))
     };
 


### PR DESCRIPTION
This adds more information about embedding and adds a section on using `browser.bundle.js` to embed JBrowse with a custom runtime-generated config.

I updated some of the embedding examples to make sure they'll actually work when published to the site, since they depend on the JBrowse that is installed on the server. You can see this in action live on a beta page I put of this doc page on the website: https://jbrowse.org/docstest/embedding.html

A couple oddities:
* The loading screen div doesn't seem to get destroyed in the embedded div example
* Is there a way to keep it from adding all the information to the URL of the page?

