### PR TITLE
add datasetLinkToParent option 

### DIFF
--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -1137,7 +1137,14 @@ renderDatasetSelect: function( parent ) {
                     if (!dsName) return false
                     const dsID = datasetChoices.find(d => d.name === dsName).id
                     const ds = (this.config.datasets||{})[dsID]
-                    if (ds) window.location = ds.url
+                    let conf = this.config;
+                    if (ds) {
+                        let link2Parent = conf.datasetLinkToParentIframe || false;
+                        if (link2Parent)
+                            window.parent.location = ds.url;
+                        else
+                            window.location = ds.url;
+                    }
                     return false
                 },
             })
@@ -1164,10 +1171,10 @@ renderDatasetSelect: function( parent ) {
                         id: 'menubar_dataset_bookmark_' + id,
                         label: id == this.config.dataset_id ? ('<b>' + dataset.name + '</b>') : dataset.name,
                         iconClass: 'dijitIconBookmark',
-                        onClick: dojo.hitch( dataset, function() { 
+                        onClick: dojo.hitch( dataset, function() {
 
-                            // if datasetLinkToParent=true, link to parent of iframe.
-                            let link2Parent = conf.datasetLinkToParent || false;
+                            // if datasetLinkToParentIframe=true, link to parent of iframe.
+                            let link2Parent = conf.datasetLinkToParentIframe || false;
                             if (link2Parent)
                                 window.parent.location = this.url;
                             else

--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -1149,6 +1149,7 @@ renderDatasetSelect: function( parent ) {
         }
     }
     else {
+        let conf = this.config;
         if( this.config.datasets && this.config.dataset_id ) {
             this.addGlobalMenuItem( 'dataset',
                     new dijitMenuSeparator() );
@@ -1163,7 +1164,15 @@ renderDatasetSelect: function( parent ) {
                         id: 'menubar_dataset_bookmark_' + id,
                         label: id == this.config.dataset_id ? ('<b>' + dataset.name + '</b>') : dataset.name,
                         iconClass: 'dijitIconBookmark',
-                        onClick: dojo.hitch( dataset, function() { window.location = this.url } )
+                        onClick: dojo.hitch( dataset, function() { 
+
+                            // if datasetLinkToParent=true, link to parent of iframe.
+                            let link2Parent = conf.datasetLinkToParent || false;
+                            if (link2Parent)
+                                window.parent.location = this.url;
+                            else
+                                window.location = this.url;
+                        })
                     })
                   );
                 }


### PR DESCRIPTION
Complements genome bookmark feature (for datasets under the Genome menu).

if defined in config, the selected dataset will load into the parent of an iframe, instead of in the iframe.

e.g.:
```
        "datasetLinkParent":true,
        "datasets": {
                "wheat": {
                        "name": "Wheat",
                        "url":"http://localhost/a.html",
                },
                "barley": {
                        "name": "Barley",
                        "url":"http://localhost/b.html",
                }
        }
```