### PR TITLE
Fix whitespace in flatfile keys and values

### DIFF
--- a/src/perl5/Bio/JBrowse/FeatureStream/GFF3_LowLevel.pm
+++ b/src/perl5/Bio/JBrowse/FeatureStream/GFF3_LowLevel.pm
@@ -61,7 +61,8 @@ sub _to_hashref {
         my $lck = lc $key;
         $lck =~ s/^\s+|\s+$//g;
         if( !$skip_attributes{$key} ) {
-            push @{ $h{$lck} ||= [] }, @{$a->{$key}};
+            my @vals = map { s/^\s+|\s+$//g; $_ } @{$a->{$key}};
+            push @{ $h{$lck} ||= [] }, @vals;
         }
     }
 

--- a/src/perl5/Bio/JBrowse/FeatureStream/GFF3_LowLevel.pm
+++ b/src/perl5/Bio/JBrowse/FeatureStream/GFF3_LowLevel.pm
@@ -10,7 +10,6 @@ use strict;
 use warnings;
 
 use base 'Bio::JBrowse::FeatureStream';
-
 sub next_items {
     my ( $self ) = @_;
     while ( my $items = $self->{parser}->next_item ) {
@@ -60,6 +59,7 @@ sub _to_hashref {
     my %skip_attributes = ( Parent => 1 );
     for my $key ( sort keys %{ $a || {} } ) {
         my $lck = lc $key;
+        $lck =~ s/^\s+|\s+$//g;
         if( !$skip_attributes{$key} ) {
             push @{ $h{$lck} ||= [] }, @{$a->{$key}};
         }

--- a/tests/data/whitespace.gff3
+++ b/tests/data/whitespace.gff3
@@ -1,0 +1,1 @@
+ctgA	example	contig	1	50001	.	.	.	Name=ctgA; multivalue= val1,val2,val3; testing = blah

--- a/tests/perl_tests/flatfile-to-json.pl.t
+++ b/tests/perl_tests/flatfile-to-json.pl.t
@@ -3,7 +3,6 @@ use warnings;
 
 
 use JBlibs;
-
 use Test::More;
 use Test::Warn;
 
@@ -259,7 +258,7 @@ sub tempdir {
     is( scalar @{$cds_trackdata->{intervals}{nclist}[0][$index][0][$index_subfeature]}, 7, 'mRNA has 7 subfeatures' );
 }
 
-{   
+{
     # diag "testing options to set class name in trackList.json";
 
     my $tempdir = tempdir();
@@ -288,7 +287,7 @@ sub tempdir {
     ok( $trackList->{'tracks'}->[0]->{'style'}->{'className'} eq 'flingwibbit', "cssClassName set correctly");
 }
 
-{   
+{
     # diag "testing options to set track type in trackList.json";
 
     my $tempdir = tempdir();
@@ -436,5 +435,39 @@ QUANTGFF3:
               }) or diag explain $trackdata->{'trackData.jsonz'};
 
 }
+{
+    # test for whitespace trimming
+    my $tempdir = tempdir();
+    run_with (
+        '--out' => $tempdir,
+        '--gff' => catfile('tests','data','whitespace.gff3'),
+        '--trackLabel' => 'whitespace',
+        );
 
+
+    my $read_json = sub { slurp( $tempdir, @_ ) };
+    my $trackdata = FileSlurping::slurp_tree( catdir( $tempdir, qw( tracks whitespace ctgA )))->{'trackData.json'};
+    is( $trackdata->{featureCount}, 1, 'got right feature count' ) or diag explain $trackdata;
+
+    is_deeply($trackdata->{intervals}->{nclist}[0][4], ['val1','val2','val3'], 'array whitespace trimmed');
+    is_deeply($trackdata->{intervals}->{nclist}[0][8], 'blah', 'normal whitespace trimmed');
+
+    is_deeply( $trackdata->{intervals}{classes}[0],
+               {
+                   'attributes' => [
+                       'Start',
+                       'End',
+                       'Strand',
+                       'Multivalue',
+                       'Name',
+                       'Seq_id',
+                       'Source',
+                       'Testing',
+                       'Type'
+                   ],
+                   'isArrayAttr' => {
+                       'Multivalue' => 1
+                   }
+              }) or diag explain $trackdata->{intervals}{classes}[0];
+}
 done_testing;

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,9 +177,9 @@
     util.promisify "^1.0.0"
 
 "@gmod/gff@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@gmod/gff/-/gff-1.1.1.tgz#ea7076bb81e8e99c24e85d0248081dcf41a8307f"
-  integrity sha1-6nB2u4Ho6Zwk6F0CSAgdz0GoMH8=
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@gmod/gff/-/gff-1.1.2.tgz#b436b8e322bb1364384db46e7d26ea2efbece7db"
+  integrity sha512-zuXx+UY8grX9denkns6l8hS+Uo9lGpoN2Wi7dDAfSrllWAQqg0hG6uX7CRfFRkt8ulxEWfIvqou2iqWwBaGBBA==
   dependencies:
     babel-runtime "^6.26.0"
     es6-promisify "^6.0.0"
@@ -1330,10 +1330,15 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.0.0, bluebird@^3.1.1, bluebird@^3.5.0, bluebird@^3.5.1:
+bluebird@^3.0.0, bluebird@^3.1.1, bluebird@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
   integrity sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==
+
+bluebird@^3.5.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
+  integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -2944,9 +2949,9 @@ es6-promisify@^5.0.0:
     es6-promise "^4.0.3"
 
 es6-promisify@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.0.0.tgz#b526a75eaa5ca600e960bf3d5ad98c40d75c7203"
-  integrity sha512-8Tbqjrb8lC85dd81haajYwuRmiU2rkqNAFnlvQOJeeKqdUloIlI+JcUqeJruV4rCm5Y7oNU7jfs2FbmxhRR/2g==
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.0.1.tgz#6edaa45f3bd570ffe08febce66f7116be4b1cdb6"
+  integrity sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==
 
 es6-set@~0.1.5:
   version "0.1.5"


### PR DESCRIPTION
This performs whitespace trimming on the attribute keys and values in a GFF3. Multivalued comma separated lists of things in the GFF3 attributes also individually get the start and end trimming.