### PR TITLE
Speed up VCF initial load

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@gmod/tabix": "^1.1.2",
     "@gmod/tribble-index": "^2.0.1",
     "@gmod/twobit": "^1.1.2",
-    "@gmod/vcf": "^1.0.4",
+    "@gmod/vcf": "^2.0.0",
     "ajv": "^6.2.1",
     "ava": "^0.25.0",
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@gmod/tabix": "^1.1.2",
     "@gmod/tribble-index": "^2.0.1",
     "@gmod/twobit": "^1.1.2",
-    "@gmod/vcf": "^2.0.0",
+    "@gmod/vcf": "^2.0.1",
     "ajv": "^6.2.1",
     "ava": "^0.25.0",
     "babel-core": "^6.26.0",

--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -718,7 +718,8 @@ regularizeReferenceName: function( refname ) {
                      .replace(/^co?n?ti?g/,'ctg')
                      .replace(/^scaff?o?l?d?/,'scaffold')
                      .replace(/^([a-z]*)0+/,'$1')
-                     .replace(/^(\d+)$/, 'chr$1' );
+                     .replace(/^(\d+|x|y)$/, 'chr$1' )
+                     .replace(/^mt$/, 'chrm');
 
     return refname;
 },

--- a/src/JBrowse/Model/VCFFeature.js
+++ b/src/JBrowse/Model/VCFFeature.js
@@ -97,7 +97,7 @@ function (Util) {
                 start: start,
                 end: end,
                 seq_id: variant.CHROM,
-                description: description,
+                description: Util.escapeHTML( description ),
                 type: SO_term,
                 reference_allele: ref
             };
@@ -128,7 +128,7 @@ function (Util) {
                     meta: {
                         description: 'VCF ALT field, list of alternate non-reference alleles called on at least one of the samples'
                     },
-                    values: alt
+                    values: alt.map( Util.escapeHTML )
                 };
             }
 

--- a/src/JBrowse/Model/VCFFeature.js
+++ b/src/JBrowse/Model/VCFFeature.js
@@ -185,7 +185,7 @@ function (Util) {
             if (descriptions.size > 1) {
                 const prefixes = new Set();
                 [...descriptions].forEach(desc => {
-                    const prefix = desc.match(/(\w+? \w+? -> )\w+/)
+                    const prefix = desc.match(/(\w+? \w+? -> )(?:<)\w+(?:>)/)
                     if (prefix && prefix[1]) prefixes.add(prefix[1])
                     else prefixes.add(desc)
                 });

--- a/src/JBrowse/Util.js
+++ b/src/JBrowse/Util.js
@@ -41,6 +41,10 @@ Util = {
         return str.toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     },
 
+    unescapeHTML: function( str ) {
+        return str.toString().replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+    },
+
     /**
      * Fast, simple class-maker, used for classes that need speed more
      * than they need dojo.declare's nice features.

--- a/src/JBrowse/View/DetailsMixin.js
+++ b/src/JBrowse/View/DetailsMixin.js
@@ -255,6 +255,7 @@ return declare( null, {
     },
 
     _valToString: function( val ) {
+        if ( !val ) return ''
         if( lang.isArray( val ) ) {
             return array.map( val, lang.hitch( this,'_valToString') ).join(' ');
         }

--- a/src/JBrowse/View/DetailsMixin.js
+++ b/src/JBrowse/View/DetailsMixin.js
@@ -206,7 +206,7 @@ return declare( null, {
             }
         }
 
-        domConstruct.create('div', { className: 'value '+class_, innerHTML: Util.escapeHTML( val ) }, parent );
+        domConstruct.create('div', { className: 'value '+class_, innerHTML: val }, parent );
         return 1;
     },
 

--- a/src/JBrowse/View/DetailsMixin.js
+++ b/src/JBrowse/View/DetailsMixin.js
@@ -206,7 +206,7 @@ return declare( null, {
             }
         }
 
-        domConstruct.create('div', { className: 'value '+class_, innerHTML: val }, parent );
+        domConstruct.create('div', { className: 'value '+class_, innerHTML: Util.escapeHTML( val ) }, parent );
         return 1;
     },
 

--- a/src/JBrowse/View/FeatureGlyph/Box.js
+++ b/src/JBrowse/View/FeatureGlyph/Box.js
@@ -1,18 +1,18 @@
 define([
            'dojo/_base/declare',
-           'dojo/_base/array',
            'dojo/_base/lang',
            'JBrowse/Util/FastPromise',
            'JBrowse/View/FeatureGlyph',
-           './_FeatureLabelMixin'
-       ],
+           './_FeatureLabelMixin',
+           'JBrowse/Util',
+        ],
        function(
            declare,
-           array,
            lang,
            FastPromise,
            FeatureGlyph,
-           FeatureLabelMixin
+           FeatureLabelMixin,
+           Util,
        ) {
 
 
@@ -327,7 +327,7 @@ return declare([ FeatureGlyph, FeatureLabelMixin], {
                 if (clearTop) context.clearRect(labelLeft,clearTop,fLabelRecord.w,fLabelRecord.h)
 
                 context.fillText(
-                    fLabelRecord.text,
+                    Util.unescapeHTML(fLabelRecord.text),
                     labelLeft,
                     labelTop
                 )

--- a/src/JBrowse/View/Track/CanvasFeatures.js
+++ b/src/JBrowse/View/Track/CanvasFeatures.js
@@ -919,7 +919,7 @@ return declare(
                             labelSpan.style.display = 'block';
                             labelSpan.style.font = label.font;
                             labelSpan.style.color = label.fill;
-                            labelSpan.innerHTML = Util.escapeHTML( label.text );
+                            labelSpan.innerHTML = label.text;
                         } else {
                             labelSpan.style.display = 'none';
                             labelSpan.innerHTML = '(no label)';
@@ -928,7 +928,7 @@ return declare(
                             descriptionSpan.style.display = 'block';
                             descriptionSpan.style.font = description.font;
                             descriptionSpan.style.color = description.fill;
-                            descriptionSpan.innerHTML = Util.escapeHTML( description.text );
+                            descriptionSpan.innerHTML = description.text;
                         }
                         else {
                             descriptionSpan.style.display = 'none';

--- a/src/JBrowse/View/Track/CanvasFeatures.js
+++ b/src/JBrowse/View/Track/CanvasFeatures.js
@@ -919,7 +919,7 @@ return declare(
                             labelSpan.style.display = 'block';
                             labelSpan.style.font = label.font;
                             labelSpan.style.color = label.fill;
-                            labelSpan.innerHTML = label.text;
+                            labelSpan.innerHTML = Util.escapeHTML( label.text );
                         } else {
                             labelSpan.style.display = 'none';
                             labelSpan.innerHTML = '(no label)';
@@ -928,7 +928,7 @@ return declare(
                             descriptionSpan.style.display = 'block';
                             descriptionSpan.style.font = description.font;
                             descriptionSpan.style.color = description.fill;
-                            descriptionSpan.innerHTML = description.text;
+                            descriptionSpan.innerHTML = Util.escapeHTML( description.text );
                         }
                         else {
                             descriptionSpan.style.display = 'none';

--- a/src/JBrowse/View/Track/Wiggle/XYPlot.js
+++ b/src/JBrowse/View/Track/Wiggle/XYPlot.js
@@ -208,11 +208,11 @@ var XYPlot = declare( [WiggleBase, YScaleMixin],
                         thisB._fillRectMod( context, 0, varTop, canvas.width, varHeight );
                         context.font = '12px sans-serif';
                         if( plusminus > 0 ) {
-                            context.fillText( '+'+label, 2, varTop );
-                            context.fillText( '-'+label, 2, varTop+varHeight );
+                            context.fillText( Util.unescapeHTML( '+'+label ), 2, varTop );
+                            context.fillText( Util.unescapeHTML( '-'+label ), 2, varTop+varHeight );
                         }
                         else {
-                            context.fillText( label, 2, varTop );
+                            context.fillText( Util.unescapeHTML( label ), 2, varTop );
                         }
                     };
 

--- a/src/JBrowse/View/Track/_VariantDetailMixin.js
+++ b/src/JBrowse/View/Track/_VariantDetailMixin.js
@@ -43,7 +43,7 @@ return declare( [FeatureDetailMixin, NamedFeatureFiltersMixin], {
     },
     renderDetailValue: function( parent, title, val, f, class_ ) {
         if(title == "alternative_alleles") {
-            val = Util.escapeHTML(val.join(','));
+            val = val.join(',');
         }
         return this.inherited(arguments, [parent,title,val,f,class_]);
     },

--- a/src/JBrowse/View/Track/_VariantDetailMixin.js
+++ b/src/JBrowse/View/Track/_VariantDetailMixin.js
@@ -141,7 +141,9 @@ return declare( [FeatureDetailMixin, NamedFeatureFiltersMixin], {
 
     _mungeGenotypeVal: function( values, alt, underlyingRefSeq ) {
         // handle the GT field specially, translating the genotype indexes into the actual ALT strings
-        var value_parse = values[0];
+        let value_parse;
+        if (values === null) value_parse = '.';
+        else value_parse = values[0];
 
         var splitter = (value_parse.match(/[\|\/]/g)||[])[0]; // only accept | and / splitters since . can mean no call
         alt = alt[0].split(','); // force split on alt alleles
@@ -163,7 +165,9 @@ return declare( [FeatureDetailMixin, NamedFeatureFiltersMixin], {
         for( var gname in genotypes ) {
             if( genotypes.hasOwnProperty( gname ) ) {
                 // increment the appropriate count
-                var gt = genotypes[gname].GT.values[0].split(/\||\//);
+                var gtVals = genotypes[gname].GT.values
+                if (gtVals === null) gtVals = ['.']
+                var gt = gtVals[0].split(/\||\//);
                 if( lang.isArray( gt ) ) {
                     // if all zero, non-variant/hom-ref
                     if( array.every( gt, function( g ) { return parseInt(g) == 0; }) ) {

--- a/src/JBrowse/View/Track/_VariantDetailMixin.js
+++ b/src/JBrowse/View/Track/_VariantDetailMixin.js
@@ -115,7 +115,7 @@ return declare( [FeatureDetailMixin, NamedFeatureFiltersMixin], {
                                    })(),
                     renderCell: {
                         "GT": function( field, value, node, options ) {
-                            thisB.renderDetailValue( node, '', Util.escapeHTML(value), f, '' );
+                            thisB.renderDetailValue( node, '', value, f, '' );
                         }
                     }
                 }

--- a/tests/js_tests/spec/VCF.spec.js
+++ b/tests/js_tests/spec/VCF.spec.js
@@ -62,7 +62,7 @@ describe('VCF store', function() {
                           );
          runs(function() {
                   expect(features.length).toEqual( 7 );
-                  expect(features[2].get('alternative_alleles').values).toEqual([ "TC", "<*>" ]);
+                  expect(features[2].get('alternative_alleles').values).toEqual([ "TC", "&lt;*&gt;" ]);
          });
 
 
@@ -122,7 +122,7 @@ describe('VCF store', function() {
                           );
          runs(function() {
                   expect(features.length).toEqual( 37 );
-                  expect(features[0].get('alternative_alleles').values).toEqual([ '<NON_REF>' ]);
+                  expect(features[0].get('alternative_alleles').values).toEqual([ '&lt;NON_REF&gt;' ]);
          });
   });
 
@@ -191,7 +191,7 @@ describe('VCF store', function() {
             start: 1206810422,
             end: 1206810423,
             seq_id: '1',
-            description: 'SNV T -> A',
+            description: 'SNV T -&gt; A',
             type: 'SNV',
             reference_allele: 'T',
             score: 25,

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,10 +223,10 @@
     long "^4.0.0"
     object.values "^1.0.4"
 
-"@gmod/vcf@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@gmod/vcf/-/vcf-1.0.4.tgz#bf58bb9b3df33d621665dfc1a2d7ad0dcbc13ab8"
-  integrity sha512-B/eGsSYKs1UuvjOMIiXzK/Io0Mad4yzn+xV9nbvhSOnToGn81vo7jH9ROyAZFmnw+2giZ+ik2+iDu2BlK4MBKQ==
+"@gmod/vcf@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@gmod/vcf/-/vcf-2.0.0.tgz#0deb7d513d4f6097890cd8d2a8bce05c09926a3c"
+  integrity sha512-gh/skF4FyzvllKbde8c86dkucvY2CjwPACOHwtsEzAQwxsBjldxjNW7Lz+fbR2jOvlNhfs0AwsHAeWvXJvEQbQ==
   dependencies:
     npm-watch "^0.3.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,10 +223,10 @@
     long "^4.0.0"
     object.values "^1.0.4"
 
-"@gmod/vcf@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@gmod/vcf/-/vcf-2.0.0.tgz#0deb7d513d4f6097890cd8d2a8bce05c09926a3c"
-  integrity sha512-gh/skF4FyzvllKbde8c86dkucvY2CjwPACOHwtsEzAQwxsBjldxjNW7Lz+fbR2jOvlNhfs0AwsHAeWvXJvEQbQ==
+"@gmod/vcf@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@gmod/vcf/-/vcf-2.0.1.tgz#4441d94412a007843b414451a4e21f9fd17d2448"
+  integrity sha512-dZJgdQQ6H17D8D0nq8BUADAy6vdd4mw3Km/nxFRRqNwcOt4xgwyldeOB8SUEZpS4PmR6EfMb0W/IajHilQ/ZAg==
   dependencies:
     npm-watch "^0.3.0"
 


### PR DESCRIPTION
Incorporates a new version of \@gmod/vcf which should speed up the initial load of a VCF that has a lot of samples.

@cmdcolin can you see if this branch speeds things up on your machine?

Volvox track with >1000 samples loads in <2s for me.
![image](https://user-images.githubusercontent.com/25592344/48152860-f5b23680-e292-11e8-98a0-cf0e94953994.png)

Resolves #1255
