### PR TITLE
Fixup genotype table for nocall

### DIFF
--- a/src/JBrowse/Model/VCFFeature.js
+++ b/src/JBrowse/Model/VCFFeature.js
@@ -11,8 +11,8 @@ function (Util) {
             this._id = args.id;
             this.data = this.dataFromVariant(this.variant);
         },
-        
-        get(field) { 
+
+        get(field) {
             return this._get(field) || this._get(field.toLowerCase())
         },
 
@@ -62,18 +62,23 @@ function (Util) {
                 Object.keys(variant.SAMPLES).forEach(sample => {
                     this.data.genotypes[sample] = {}
                     Object.keys(variant.SAMPLES[sample]).forEach(field => {
-                        this.data.genotypes[sample][field] = {
-                            meta: {
-                                id: [field],
-                            },
-                            values: variant.SAMPLES[sample][field]
+                        if(variant.SAMPLES[sample][field]) {
+                            this.data.genotypes[sample][field] = {
+                                meta: {
+                                    id: [field],
+                                },
+                                values: variant.SAMPLES[sample][field]
+                            }
+                            const metadata = this.parser.getMetadata('FORMAT', field);
+                            if (metadata) {
+                                const { Description, Number, Type } = metadata
+                                this.data.genotypes[sample][field].meta.Description = [Description]
+                                this.data.genotypes[sample][field].meta.Number = Number
+                                this.data.genotypes[sample][field].meta.Type = Type
+                            }
                         }
-                        const metadata = this.parser.getMetadata('FORMAT', field);
-                        if (metadata) {
-                            const { Description, Number, Type } = metadata
-                            this.data.genotypes[sample][field].meta.Description = [Description]
-                            this.data.genotypes[sample][field].meta.Number = Number
-                            this.data.genotypes[sample][field].meta.Type = Type
+                        else {
+                            this.data.genotypes[sample][field] = {values: null}
                         }
                     })
                 })
@@ -253,7 +258,7 @@ function (Util) {
 
         _getSOAndDescByExamination: function (ref, alt) {
             if (ref.length == 1 && alt.length == 1) {
-                // use SNV because SO definition of SNP says abundance must be at 
+                // use SNV because SO definition of SNP says abundance must be at
                 // least 1% in population, and can't be sure we meet that
                 return [
                     'SNV',

--- a/src/JBrowse/Model/VCFFeature.js
+++ b/src/JBrowse/Model/VCFFeature.js
@@ -62,23 +62,8 @@ function (Util) {
                 Object.keys(variant.SAMPLES).forEach(sample => {
                     this.data.genotypes[sample] = {}
                     Object.keys(variant.SAMPLES[sample]).forEach(field => {
-                        if(variant.SAMPLES[sample][field]) {
-                            this.data.genotypes[sample][field] = {
-                                meta: {
-                                    id: [field],
-                                },
-                                values: variant.SAMPLES[sample][field]
-                            }
-                            const metadata = this.parser.getMetadata('FORMAT', field);
-                            if (metadata) {
-                                const { Description, Number, Type } = metadata
-                                this.data.genotypes[sample][field].meta.Description = [Description]
-                                this.data.genotypes[sample][field].meta.Number = Number
-                                this.data.genotypes[sample][field].meta.Type = Type
-                            }
-                        }
-                        else {
-                            this.data.genotypes[sample][field] = {values: null}
+                        this.data.genotypes[sample][field] = {
+                            values: variant.SAMPLES[sample][field]
                         }
                     })
                 })

--- a/src/JBrowse/View/Track/_VariantDetailMixin.js
+++ b/src/JBrowse/View/Track/_VariantDetailMixin.js
@@ -146,7 +146,6 @@ return declare( [FeatureDetailMixin, NamedFeatureFiltersMixin], {
         else value_parse = values[0];
 
         var splitter = (value_parse.match(/[\|\/]/g)||[])[0]; // only accept | and / splitters since . can mean no call
-        alt = alt[0].split(','); // force split on alt alleles
         var refseq = underlyingRefSeq ? 'ref ('+underlyingRefSeq+')' : 'ref';
         values = array.map( splitter ? value_parse.split(splitter) : value_parse, function( gtIndex ) {
                                 gtIndex = parseInt( gtIndex ) || gtIndex;

--- a/tests/js_tests/spec/VCF.spec.js
+++ b/tests/js_tests/spec/VCF.spec.js
@@ -266,30 +266,15 @@ describe('VCF store', function() {
           expect(features[0].get('genotypes')).toEqual({
             'sample_data/raw/volvox/volvox-sorted.bam': {
             GT: {
-                meta: {
-                Description: ['Genotype'],
-                id: ['GT'],
-                Number: 1,
-                Type: 'String',
-                },
+
                 values: ['0/1'],
             },
             PL: {
-                meta: {
-                Description: ['List of Phred-scaled genotype likelihoods'],
-                id: ['PL'],
-                Number: 'G',
-                Type: 'Integer',
-                },
+
                 values: [55, 0, 73],
             },
             GQ: {
-                meta: {
-                Description: ['Genotype Quality'],
-                id: ['GQ'],
-                Number: 1,
-                Type: 'Integer',
-                },
+
                 values: [58],
             },
             },


### PR DESCRIPTION
If there are elements with no-call attributes with no supporting data, then it displays the genotype table somewhat weirdly

Before
![screenshot-localhost-2018 11 24-15-26-50](https://user-images.githubusercontent.com/6511937/48972719-d6d7d200-effe-11e8-8955-96a9dd1c8778.png)

After
![screenshot-localhost-2018 11 24-15-36-11](https://user-images.githubusercontent.com/6511937/48972723-ddfee000-effe-11e8-8421-a552b1651b6a.png)

The no-call data in volvox had supporting data for the no-calls so this wasn't detected there

Also, maybe it is not necessary to add the metadata to all VCF genotypes?

