### PR TITLE
Add a fix for CRAM displaying on wrong chromosome

### DIFF
--- a/src/JBrowse/Store/SeqFeature/CRAM.js
+++ b/src/JBrowse/Store/SeqFeature/CRAM.js
@@ -210,7 +210,7 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, Gl
     _refNameToId(refName) {
         // use info from the SAM header if possible, but fall back to using
         // the ref seq order from when the browser's refseqs were loaded
-        if (this._samHeader.refSeqNameToId && refName in this._samHeader.refSeqNameToId)
+        if (this._samHeader.refSeqNameToId)
             return this._samHeader.refSeqNameToId[refName]
         else
             return this.browser.getRefSeqNumber(refName)


### PR DESCRIPTION
Ref #1273 

This avoids the additional check for the refseq existing in the samHeader so that when it does not exist it doesn't try and do any fallbacks