### PR TITLE
No content range fixes

### DIFF
--- a/src/JBrowse/Model/XHRBlob.js
+++ b/src/JBrowse/Model/XHRBlob.js
@@ -68,12 +68,6 @@ function fetchBinaryRange(url, start, end) {
         )
       }
 
-      // if we now still have no content-range header, the most common reason
-      // is because the remote server doesn't support CORS
-      if (!headers['content-range']) {
-          throw new Error(`could not read Content-Range for ${url}, the remote server may not support JBrowse (need CORS and HTTP Range requests)`)
-      }
-
       // return the response headers, and the data buffer
       return res.arrayBuffer()
         .then(arrayBuffer => ({


### PR DESCRIPTION
This adds some changes to bypass http-range-fetcher basically when there are full file requests like for an index file, where in that case the range end is undefined and start is just 0

Addresses #1289 

Could also be addressed on the http-range-fetcher side of things but I basically saw it as unnecessary to divide into chunks so it is implemented with plain fetches here (with a small extra lru cache)