### PR TITLE
Optional fix bounds on XYPlot ruler

### DIFF
--- a/docs/site/config_bigwig.md
+++ b/docs/site/config_bigwig.md
@@ -75,6 +75,7 @@ Here is an example track configuration stanza for a Wiggle color-density track d
 |`scoreType`|The scoreType to be used at the summary level. Options: maxScore, avgScore, score, minScore. Default: score is the backwards compatible default which is an average score when zoomed out, max score when zoomed in. maxScore is max score zoomed out and max score zoomed in. avgScore is both average score zoomed in and average score zoomed out. avgScore added in 1.12.0. maxScore/minScore added in 1.11.6.|
 |`logScaleOption`|Add or remove the "Log scale" checkbox for the track menu. Default: true. Added in 1.11.6.|
 |`noFill`|Draw the bigwig track as a "scatterplot" by not filling in the boxes. Default: false. Added in 1.12.3|
+|`fixBounds`|Rounds the min and max values that are more friendly for the tick marks on the ruler. Default, 'major'. Can also be 'none', 'micro', 'minor', and 'major'. Added in 1.16.2|
 
 ## BigWig File Compatibility
 

--- a/src/JBrowse/View/Ruler.js
+++ b/src/JBrowse/View/Ruler.js
@@ -58,8 +58,8 @@ Ruler.prototype.render_to = function( target_div ) {
                             fill: 'transparent',
                             min: this.min,
                             max: this.max,
-                            fixLower: this.fixBounds ? 'major' : 'none',
-                            fixUpper: this.fixBounds ? 'major' : 'none',
+                            fixLower: this.fixBounds ? typeof this.fixBounds=='string'?this.fixBounds: 'major' : 'none',
+                            fixUpper: this.fixBounds ? typeof this.fixBounds=='string'?this.fixBounds: 'major' : 'none',
                             leftBottom: this.leftBottom
                             // minorTickStep: 0.5,
                             // majorTickStep: 1

--- a/src/JBrowse/View/Ruler.js
+++ b/src/JBrowse/View/Ruler.js
@@ -58,8 +58,8 @@ Ruler.prototype.render_to = function( target_div ) {
                             fill: 'transparent',
                             min: this.min,
                             max: this.max,
-                            fixLower: this.fixBounds ? typeof this.fixBounds=='string'?this.fixBounds: 'major' : 'none',
-                            fixUpper: this.fixBounds ? typeof this.fixBounds=='string'?this.fixBounds: 'major' : 'none',
+                            fixLower: this.fixBounds ? (typeof this.fixBounds=='string' ? this.fixBounds : 'major') : 'none',
+                            fixUpper: this.fixBounds ? (typeof this.fixBounds=='string' ? this.fixBounds : 'major') : 'none',
                             leftBottom: this.leftBottom
                             // minorTickStep: 0.5,
                             // majorTickStep: 1

--- a/src/JBrowse/View/Track/Wiggle/XYPlot.js
+++ b/src/JBrowse/View/Track/Wiggle/XYPlot.js
@@ -69,7 +69,7 @@ var XYPlot = declare( [WiggleBase, YScaleMixin],
 
                 // update our track y-scale to reflect it
                 this.makeYScale({
-                    fixBounds: true,
+                    fixBounds: 'fixBounds' in this.config.fixBounds?this.config.fixBounds:true,
                     min: scaling.min,
                     max: scaling.max
                 });

--- a/src/JBrowse/View/Track/Wiggle/XYPlot.js
+++ b/src/JBrowse/View/Track/Wiggle/XYPlot.js
@@ -69,7 +69,7 @@ var XYPlot = declare( [WiggleBase, YScaleMixin],
 
                 // update our track y-scale to reflect it
                 this.makeYScale({
-                    fixBounds: 'fixBounds' in this.config.fixBounds?this.config.fixBounds:true,
+                    fixBounds: 'fixBounds' in this.config ? this.config.fixBounds : true,
                     min: scaling.min,
                     max: scaling.max
                 });


### PR DESCRIPTION
This adds fixBounds config to XYPlot tracks which can be set to false, "none", "micro", "minor", or "major" (default major, setting to false == 'none')

Applies to both fixLower and fixUpper in https://dojotoolkit.org/reference-guide/1.10/dojox/charting.html