### PR TITLE
Display gene subfeatures even if topLevelFeatures is not set

### DIFF
--- a/jbrowse.conf
+++ b/jbrowse.conf
@@ -59,6 +59,8 @@
 ## sequence dropdown
 # refSeqOrder = length descending
 
+## Uncomment to prevent HTML tracks from displaying gene subfeatures (enabled by default)
+# inferHTMLSubfeatures = false
 
 ## to set a default data directory other than 'data', uncomment and
 ## edit the line below
@@ -92,4 +94,3 @@ include += {dataRoot}/tracks.conf
 # [datasets.yeast]
 # url  = ?data=sample_data/json/yeast
 # name = Yeast Example
-

--- a/src/JBrowse/View/Track/HTMLFeatures.js
+++ b/src/JBrowse/View/Track/HTMLFeatures.js
@@ -702,14 +702,36 @@ define( [
              */
             addFeatureToBlock: function( feature, uniqueId, block, scale, labelScale, descriptionScale,
                                          containerStart, containerEnd ) {
-                var featDiv = this.renderFeature( feature, uniqueId, block, scale, labelScale, descriptionScale,
-                    containerStart, containerEnd );
-                if( ! featDiv )
-                    return null;
+                var thisB = this;
+                if( feature.get('type') == 'gene') {
+                    var d = dojo.create('div');
+                    var feats = feature.get('subfeatures');
+                    if(!feats) {
+                        return null;
+                    }
+                    feats.forEach(function( feat ) {
+                        if (!thisB._featureIsRendered(uniqueId + '_' + feat.get('id'))) {
+                            featDiv = thisB.renderFeature(feat, uniqueId + '_' + feat.get('id'), block, scale, labelScale, descriptionScale, containerStart, containerEnd);
+                            d.appendChild( featDiv );
+                        }
+                    });
+                    block.domNode.appendChild( d );
+                    if( this.config.style.centerChildrenVertically ) {
+                        d.childNodes.forEach(function( featDiv ) {
+                            thisB._centerChildrenVertically( featDiv );
+                        });
+                    }
+                    return d;
+                } else {
+                    var featDiv = this.renderFeature( feature, uniqueId, block, scale, labelScale, descriptionScale,
+                        containerStart, containerEnd );
+                    if( ! featDiv )
+                        return null;
 
-                block.domNode.appendChild( featDiv );
-                if( this.config.style.centerChildrenVertically )
-                    this._centerChildrenVertically( featDiv );
+                    block.domNode.appendChild( featDiv );
+                    if( this.config.style.centerChildrenVertically )
+                        this._centerChildrenVertically( featDiv );
+                }
                 return featDiv;
             },
 
@@ -1173,6 +1195,11 @@ define( [
                         this.renderSubfeature( feature, featDiv,
                             subfeatures[i],
                             displayStart, displayEnd, block );
+                        var subfeature = subfeatures[i];
+                        var subtype = subfeature.get('type');
+                        if(subtype == 'mRNA'){
+                            this.handleSubFeatures(subfeature,featDiv,displayStart,displayEnd,block);
+                        }
                     }
                 }
             },

--- a/src/JBrowse/View/Track/HTMLFeatures.js
+++ b/src/JBrowse/View/Track/HTMLFeatures.js
@@ -703,7 +703,8 @@ define( [
             addFeatureToBlock: function( feature, uniqueId, block, scale, labelScale, descriptionScale,
                                          containerStart, containerEnd ) {
                 var thisB = this;
-                if( feature.get('type') == 'gene') {
+
+                if ((typeof this.browser.config.inferHTMLSubfeatures === 'undefined' || this.browser.config.inferHTMLSubfeatures===true) && feature.get('type') == 'gene') {
                     var d = dojo.create('div');
                     var feats = feature.get('subfeatures');
                     if(!feats) {


### PR DESCRIPTION
This PR allows to display gene subfeatures in HTMLFeatures (and NeatHTMLFeature) tracks, even if topLevelFeatures is not set "properly".

This is typically for gff files containing gene > mRNA > exon/CDS data.

Setting topLevelFeatures works nice, but : 
 - people uploading gff files don't know about it, and they have no easy way to set it from the upload box (and in the end they complain about it to me)
- CanvasFeatures tracks are already able to display this kind of data with all the subfeatures
- this is such a typical gff structure that I would expect jbrowse to display it properly out of the box

The code is inspired/adapted from https://github.com/GMOD/jbrowse/pull/996

Without this patch:
![subfeats_bad](https://user-images.githubusercontent.com/238755/54548832-0db86600-49a9-11e9-8dcb-66fe410cfdf1.png)

With this patch:
![subfeats_ok](https://user-images.githubusercontent.com/238755/54548840-1315b080-49a9-11e9-8fe4-64f83bc6e46c.png)
