### PR TITLE
Add -L flag to curl in documentation

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -32,7 +32,7 @@ const v = {
 const siteVariables = {
     "version": v.version,
     "setup_snip": [
-        `    curl -O https://github.com/GMOD/jbrowse/releases/download/${v.version}-release/JBrowse-${v.version}.zip`,
+        `    curl -L -O https://github.com/GMOD/jbrowse/releases/download/${v.version}-release/JBrowse-${v.version}.zip`,
         `    unzip JBrowse-${v.version}.zip`,
         `    sudo mv JBrowse-${v.version} /var/www/html/jbrowse`,
         '    cd /var/www/html',


### PR DESCRIPTION
Redirects must be followed to download Github releases with curl. Otherwise, the downloaded object is the Github response informing about the redirect, not the released .zip file.

As of today, following the installation instructions downloads a text file containing only HTML:

```
20:22 $ curl -O https://github.com/GMOD/jbrowse/releases/download/1.16.3-release/JBrowse-1.16.3.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   606    0   606    0     0   1037      0 --:--:-- --:--:-- --:--:--  1035

20:22 $ unzip JBrowse-1.16.3.zip 
Archive:  JBrowse-1.16.3.zip
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of JBrowse-1.16.3.zip or
        JBrowse-1.16.3.zip.zip, and cannot find JBrowse-1.16.3.zip.ZIP, period.

20:22 $ cat JBrowse-1.16.3.zip 
<html><body>You are being <a href="https://github-production-release-asset-2e65be.s3.amazonaws.com/108695/4fcec300-3535-11e9-9d37-20eae87f3eb7?X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20190319%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20190319T192118Z&amp;X-Amz-Expires=300&amp;X-Amz-Signature=81f9ed88f49bac9c47871bba0ca78dd835955da22e586f753b06db8c1be61301&amp;X-Amz-SignedHeaders=host&amp;actor_id=0&amp;response-content-disposition=attachment%3B%20filename%3DJBrowse-1.16.3.zip&amp;response-content-type=application%2Foctet-stream">redirected</a>.</body></html>
```

This PR fixes the documentation adding the -L flag to the curl command.