### PR TITLE
Fix getFeatDiv when inferHTMLSubfeatures is set

### DIFF
--- a/src/JBrowse/View/Track/HTMLFeatures.js
+++ b/src/JBrowse/View/Track/HTMLFeatures.js
@@ -711,8 +711,8 @@ define( [
                         return null;
                     }
                     feats.forEach(function( feat ) {
-                        if (!thisB._featureIsRendered(uniqueId + '_' + feat.get('id'))) {
-                            featDiv = thisB.renderFeature(feat, uniqueId + '_' + feat.get('id'), block, scale, labelScale, descriptionScale, containerStart, containerEnd);
+                        if (!thisB._featureIsRendered(uniqueId + '_' + feat.get('uniqueId'))) {
+                            featDiv = thisB.renderFeature(feat, uniqueId + '_' + feat.get('uniqueId'), block, scale, labelScale, descriptionScale, containerStart, containerEnd);
                             d.appendChild( featDiv );
                         }
                     });
@@ -946,6 +946,11 @@ define( [
 
             getFeatDiv: function( feature )  {
                 var id = this.getId( feature );
+
+                if ((typeof this.browser.config.inferHTMLSubfeatures === 'undefined' || this.browser.config.inferHTMLSubfeatures===true) && feature.parent() && feature.parent().get('type') == "gene") {
+                    id = this.getId( feature.parent() ) + '_' + feature.get('uniqueId');
+                }
+
                 if( ! id )
                     return null;
 

--- a/src/JBrowse/View/Track/HTMLFeatures.js
+++ b/src/JBrowse/View/Track/HTMLFeatures.js
@@ -704,7 +704,7 @@ define( [
                                          containerStart, containerEnd ) {
                 var thisB = this;
 
-                if ((typeof this.browser.config.inferHTMLSubfeatures === 'undefined' || this.browser.config.inferHTMLSubfeatures===true) && feature.get('type') == 'gene') {
+                if ((typeof this.browser.config.inferHTMLSubfeatures === 'undefined' || this.browser.config.inferHTMLSubfeatures===true) && feature.get('type') == 'gene' && feature.get('subfeatures')) {
                     var d = dojo.create('div');
                     var feats = feature.get('subfeatures');
                     if(!feats) {
@@ -952,7 +952,7 @@ define( [
                     gene_id = this.getId( feature.parent() ) + '_' + this.getId(feature);
                 }
 
-                if( ! id  && ! gene_id )
+                if( ! id && ! gene_id )
                     return null;
 
                 for( var i = 0; i < this.blocks.length; i++ ) {

--- a/src/JBrowse/View/Track/HTMLFeatures.js
+++ b/src/JBrowse/View/Track/HTMLFeatures.js
@@ -711,8 +711,8 @@ define( [
                         return null;
                     }
                     feats.forEach(function( feat ) {
-                        if (!thisB._featureIsRendered(uniqueId + '_' + feat.get('uniqueId'))) {
-                            featDiv = thisB.renderFeature(feat, uniqueId + '_' + feat.get('uniqueId'), block, scale, labelScale, descriptionScale, containerStart, containerEnd);
+                        if (!thisB._featureIsRendered(uniqueId + '_' + thisB.getId(feat))) {
+                            featDiv = thisB.renderFeature(feat, uniqueId + '_' + thisB.getId(feat), block, scale, labelScale, descriptionScale, containerStart, containerEnd);
                             d.appendChild( featDiv );
                         }
                     });
@@ -948,7 +948,7 @@ define( [
                 var id = this.getId( feature );
 
                 if ((typeof this.browser.config.inferHTMLSubfeatures === 'undefined' || this.browser.config.inferHTMLSubfeatures===true) && feature.parent() && feature.parent().get('type') == "gene") {
-                    id = this.getId( feature.parent() ) + '_' + feature.get('uniqueId');
+                    id = this.getId( feature.parent() ) + '_' + this.getId(feature);
                 }
 
                 if( ! id )

--- a/src/JBrowse/View/Track/HTMLFeatures.js
+++ b/src/JBrowse/View/Track/HTMLFeatures.js
@@ -946,18 +946,22 @@ define( [
 
             getFeatDiv: function( feature )  {
                 var id = this.getId( feature );
+                var gene_id;
 
                 if ((typeof this.browser.config.inferHTMLSubfeatures === 'undefined' || this.browser.config.inferHTMLSubfeatures===true) && feature.parent() && feature.parent().get('type') == "gene") {
-                    id = this.getId( feature.parent() ) + '_' + this.getId(feature);
+                    gene_id = this.getId( feature.parent() ) + '_' + this.getId(feature);
                 }
 
-                if( ! id )
+                if( ! id  && ! gene_id )
                     return null;
 
                 for( var i = 0; i < this.blocks.length; i++ ) {
                     var b = this.blocks[i];
                     if( b && b.featureNodes ) {
                         var f = b.featureNodes[id];
+                        if( f )
+                            return f;
+                        f = b.featureNodes[gene_id];
                         if( f )
                             return f;
                     }


### PR DESCRIPTION
Some things were missing in https://github.com/GMOD/jbrowse/pull/1340 as a gene>mrna>exon track is now displayed properly by default, but can't be dragged in Apollo.
The Apollo issue is there: https://github.com/GMOD/Apollo/issues/2099
This is still WIP I guess, can't test more today