### PR TITLE
Fix for CRAM regularizing failing

### DIFF
--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -729,10 +729,14 @@ regularizeReferenceName: function( refname ) {
     if( this.config.exactReferenceSequenceNames )
         return refname;
 
-    // special case of double regularizing behaving badly
-    if(refname === 'chrm') return refname
-
     refname = refname.toLowerCase()
+
+    // special case of double regularizing behaving badly
+    if(refname.match(/^chrm/)) {
+        return 'chrm'
+    }
+
+    refname = refname
                      .replace(/^chro?m?(osome)?/,'chr')
                      .replace(/^co?n?ti?g/,'ctg')
                      .replace(/^scaff?o?l?d?/,'scaffold')

--- a/src/JBrowse/Browser.js
+++ b/src/JBrowse/Browser.js
@@ -729,6 +729,9 @@ regularizeReferenceName: function( refname ) {
     if( this.config.exactReferenceSequenceNames )
         return refname;
 
+    // special case of double regularizing behaving badly
+    if(refname === 'chrm') return refname
+
     refname = refname.toLowerCase()
                      .replace(/^chro?m?(osome)?/,'chr')
                      .replace(/^co?n?ti?g/,'ctg')

--- a/src/JBrowse/Store/SeqFeature/CRAM.js
+++ b/src/JBrowse/Store/SeqFeature/CRAM.js
@@ -21,7 +21,6 @@ class CramSlightlyLazyFeature {
     _get_strand() { return this.record.isReverseComplemented() ? -1 : 1 }
     _get_read_group_id() { return this.record.readGroupId }
     _get_qual() { return (this.record.qualityScores || []).map(q => q+33).join(' ')}
-    _get_seq() { return this.record.readBases}
     _get_seq_id() { return this._store._refIdToName(this.record.sequenceId)}
     _get_qc_failed() { return this.record.isFailedQc()}
     _get_secondary_alignment() { return this.record.isSecondary()}

--- a/src/JBrowse/Store/SeqFeature/IndexedFasta.js
+++ b/src/JBrowse/Store/SeqFeature/IndexedFasta.js
@@ -70,7 +70,12 @@ return declare( [ SeqFeatureStore, DeferredFeaturesMixin ],
         if(query.start < 0) {
             query.start = 0;
         }
-        this.fasta.getResiduesByName( this.refSeq.name, query.start, query.end ).then((seq) => {
+        var refname = query.ref;
+        // if they both regularize to the same thing, use this.refSeq.name since that is guaranteed to be from refseq store
+        if(!this.browser.compareReferenceNames( this.refSeq.name, refname ) )
+            refname = this.refSeq.name;
+
+        this.fasta.getResiduesByName( refname, query.start, query.end ).then(seq => {
             featCallback(new SimpleFeature({data: {seq, start: query.start, end: query.end}}))
             endCallback()
         },

--- a/src/JBrowse/Store/SeqFeature/SequenceChunks.js
+++ b/src/JBrowse/Store/SeqFeature/SequenceChunks.js
@@ -48,6 +48,7 @@ return declare( SeqFeatureStore,
         errorCallback = errorCallback || function(e) { console.error(e); };
 
         var refname = query.ref;
+        // if they both regularize to the same thing, use this.refSeq.name since that is guaranteed to be from refseq store
         if( ! this.browser.compareReferenceNames( this.refSeq.name, refname ) )
             refname = this.refSeq.name;
 

--- a/src/JBrowse/Store/SeqFeature/TwoBit.js
+++ b/src/JBrowse/Store/SeqFeature/TwoBit.js
@@ -79,7 +79,12 @@ return declare([ SeqFeatureStore, DeferredFeaturesMixin], {
         if (start < 0) {
             start = 0
         }
-        this.twoBit.getSequence(query.ref, start, query.end)
+        var refname = query.ref;
+        // if they both regularize to the same thing, use this.refSeq.name since that is guaranteed to be from refseq store
+        if(!this.browser.compareReferenceNames( this.refSeq.name, refname ) )
+            refname = this.refSeq.name;
+
+        this.twoBit.getSequence(refname, start, query.end)
             .then(seq => {
                 if (seq !== undefined) {
                     featCallback(new SimpleFeature({

--- a/tests/js_tests/spec/RegularizeRefSeqs.spec.js
+++ b/tests/js_tests/spec/RegularizeRefSeqs.spec.js
@@ -10,7 +10,13 @@ describe( 'centralized ref seq name regularization', function() {
     var testCases = [
         [ 'ctgA', 'ctga' ],
         [ 'MT', 'chrm' ],
+        [ 'Pt', 'pt' ],
+        [ 'C9', 'c9' ],
+        [ 'chrM', 'chrm' ],
+        [ 'chrMT', 'chrm' ],
+        [ 'ChrC', 'chrc' ],
         [ 'chrom01', 'chr1' ],
+        [ 'Bvchr1_un.sca002', 'bvchr1_un.sca002' ],
         [ 'chr01', 'chr1' ],
         [ 'CHROMOSOME11', 'chr11' ],
         [ 'SCAFFOLD0231', 'scaffold231' ],

--- a/tests/js_tests/spec/RegularizeRefSeqs.spec.js
+++ b/tests/js_tests/spec/RegularizeRefSeqs.spec.js
@@ -9,6 +9,7 @@ describe( 'centralized ref seq name regularization', function() {
 
     var testCases = [
         [ 'ctgA', 'ctga' ],
+        [ 'MT', 'chrm' ],
         [ 'chrom01', 'chr1' ],
         [ 'chr01', 'chr1' ],
         [ 'CHROMOSOME11', 'chr11' ],
@@ -19,11 +20,21 @@ describe( 'centralized ref seq name regularization', function() {
         [ '01', 'chr1' ],
         [ '1', 'chr1' ]
     ];
+
+
+
     array.forEach( testCases, function( testCase ) {
         it( 'works for '+testCase[0], function() {
             expect( b.regularizeReferenceName( testCase[0] ) ).toEqual( testCase[1] );
         });
     });
 
+    array.forEach( testCases, function( testCase ) {
+        it( 'double regularizing works for '+testCase[1], function() {
+            expect( b.regularizeReferenceName( testCase[1] ) ).toEqual( testCase[1] );
+        });
+    });
+})
+
 });
-});
+

--- a/tests/js_tests/spec/TwoBit.spec.js
+++ b/tests/js_tests/spec/TwoBit.spec.js
@@ -10,11 +10,12 @@ require([
             aspect,
             XHRBlob
         ) {
-    
+
 describe(".2bit data store with T_ko.2bit", function() {
 
     var t = new TwoBitStore({
             browser: new Browser({ unitTestMode: true }),
+            refSeq: { name: 'chr1', start: 1, end: 500001 },
             blob: new XHRBlob("../data/T_ko.2bit")
         });
 
@@ -55,17 +56,18 @@ describe(".2bit data store with T_ko.2bit", function() {
             function() { done = true; });
 
         waitsFor( function() { return done; }, 2000);
-        runs(function(){ 
+        runs(function(){
             expect(features.length).toEqual(0);
         });
     });
-   
+
 });
 
 describe(".2bit data store with volvox.2bit", function() {
 
     var t2 = new TwoBitStore({
             browser: new Browser({ unitTestMode: true }),
+            refSeq: { name: 'chr1', start: 1, end: 500001 },
             blob: new XHRBlob("../data/volvox.2bit")
         });
 
@@ -122,19 +124,20 @@ describe(".2bit data store with volvox.2bit", function() {
             function() { done = true; });
 
         waitsFor( function() { return done; }, 2000);
-        runs(function(){ 
+        runs(function(){
             expect(features.length).toEqual(0);
         });
     });
-   
+
 });
 
     var seqString = "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNACTCTATCTATCTATCTATCTATCTTTTTCCCCCCGGGGGGagagagagactctagcatcctcctacctcacNNacCNctTGGACNCcCaGGGatttcNNNcccNNCCNCgN";
 
 describe(".2bit data store with random data foo.2bit", function() {
-    
+
     var t3 = new TwoBitStore({
         browser: new Browser({unitTestMode: true }),
+        refSeq: { name: 'chr1', start: 1, end: 500001 },
         blob: new XHRBlob("../data/foo.2bit")
     });
 
@@ -182,6 +185,7 @@ describe(".2bit data store with random data foo.2bit", function() {
 describe("empty 2bit", function() {
     var t4 = new TwoBitStore({
         browser: new Browser({ unitTestMode: true }),
+        refSeq: { name: 'chr1', start: 1, end: 500001 },
         blob: new XHRBlob("../data/empty.2bit")
     });
 
@@ -192,9 +196,9 @@ describe("empty 2bit", function() {
     it("returns no data, but doesn't crash", function() {
         var done;
         var features = [];
-        t4.getFeatures({ref: "unimportant", start: 0, end: 4000}, 
+        t4.getFeatures({ref: "unimportant", start: 0, end: 4000},
             function(feature) {
-                features.push(feature); 
+                features.push(feature);
             },
             function() { done = true; },
             function(err) { console.log(err); });


### PR DESCRIPTION
Currently there are examples of CRAM name regularizing failing due to interaction with the sequence stores

* We have a CRAM using nomenclature `MT`
* The FASTA is using nomenclature `MT`
* The system internal to CRAM uses name regularization and makes this `chrm`
* Then it requests `chrm` from the seqFetch callback, at which point it fails


When it gets to the seq store, there is differing behavior depending on seqStore


1) The IndexedFasta does not use the query name, it uses this.refSeq.name, so it actually works
2) The SequenceChunks does something called compareReferenceSequence(this.refSeq.name, query.ref) and if this is 0, then it queries with this.refSeq.name. there was a bug with this that resulted in MT getting double regularized though so it went from MT->chrm->chr
3) The TwoBit only uses query name


The fix here is to avoid the regularization failure and make the behavior across sequence stores more consistent