### PR TITLE
NeatHTMLFeatures: fix error when too many features to display

### DIFF
--- a/plugins/NeatHTMLFeatures/js/View/Track/NeatFeatures.js
+++ b/plugins/NeatHTMLFeatures/js/View/Track/NeatFeatures.js
@@ -19,8 +19,10 @@ function (
             var featureNode = this.inherited(arguments);
             var thisB = this;
 
-            thisB.insertIntrons(featureNode);
-            thisB.paintNeatFeatures(featureNode);
+            if (featureNode) { // In case the feature was not rendered (too many)
+                thisB.insertIntrons(featureNode);
+                thisB.paintNeatFeatures(featureNode);
+            }
             return featureNode;
         },
         insertIntrons: function (featureNode) {

--- a/src/JBrowse/View/Track/HTMLFeatures.js
+++ b/src/JBrowse/View/Track/HTMLFeatures.js
@@ -713,7 +713,9 @@ define( [
                     feats.forEach(function( feat ) {
                         if (!thisB._featureIsRendered(uniqueId + '_' + thisB.getId(feat))) {
                             featDiv = thisB.renderFeature(feat, uniqueId + '_' + thisB.getId(feat), block, scale, labelScale, descriptionScale, containerStart, containerEnd);
-                            d.appendChild( featDiv );
+                            if (featDiv) { // In case the feature was not rendered (too many)
+                                d.appendChild( featDiv );
+                            }
                         }
                     });
                     block.domNode.appendChild( d );


### PR DESCRIPTION
2 small fixes to avoid error messages when there are too many features to display them all (maximum height reached).
In this case, renderFeature returns null, and we need to check this bfore trying to insertIntrons or appendChild