### PR TITLE
Add dontRedispatch defaults for GFF3Tabix

### DIFF
--- a/src/JBrowse/Store/SeqFeature/GFF3Tabix.js
+++ b/src/JBrowse/Store/SeqFeature/GFF3Tabix.js
@@ -34,7 +34,7 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, In
     supportsFeatureTransforms: true,
 
     constructor( args ) {
-        this.dontRedispatch = (args.dontRedispatch||"").split( /\s*,\s*/ );
+        this.dontRedispatch = (args.dontRedispatch || 'chromosome,region').split( /\s*,\s*/ );
         var csiBlob, tbiBlob;
 
         if(args.csi || this.config.csiUrlTemplate) {


### PR DESCRIPTION
This adds a set of defaults for dontRedispatch that corresponds to common elements, chromosome and region, that commonly trigger redispatching that doesn't really make sense.

I think this is a sensible default. It was previously argued to not use this. Note that overriding this variable would have to re-include "chromosome,region,..." if something were to be added which doesn't seem that bad.

I can update docs if this change is suitable