### PR TITLE
Allow scroll wheel to bubble if no scrolling happened

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
         - GECKODRIVER_VERSION=0.19.1
 before_install:
   - sudo dpkg --add-architecture i386
-  - sudo apt-get -qq update
   - sudo apt-get install wine1.6 # this is for building windows electron images
 install:
 - mkdir ~/geckodriver_$GECKODRIVER_VERSION;

--- a/docs/site/global_options.md
+++ b/docs/site/global_options.md
@@ -45,6 +45,7 @@ JBrowse supports some other configuration variables that customize the overall b
 |`trackLabels`|Set "trackLabels": "no-block" to enable the trackLabels to be out of the way of the features. Added in 1.12.5|
 |`allowCrossOriginDataRoot`|Allows dataRoot or the ?data= url parameter to point to a remote directory. Default false. This can introduce XSS so it is not recommended on sites that have logins. Note this is set through index.html with the data-config attribute on the GenomeBrowser div|
 |`cacheBuster`|Sets a randomized value ?v= on requests to configuration files to avoid aggressive browser caching. Default true. Note this is set through index.html with the data-config attribute on the GenomeBrowser div|
+|`alwaysStopScrollBubble`|Since JBrowse 1.16.5 the scroll event can bubble the vertical scroll event instead of capturing and stopping it. This can allow for a more intuitive scrolling in a larger embedded page. If this is unwanted, add `alwaysStopScrollBubble: true`|
 
 ## Generic Track Configuration Options
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -17,9 +17,15 @@
    actual fileOffset to be used instead of CRC32 hash of the line
    (@cmdcolin)
 
- * Add regularization of chromosome names using roman numerals,
+ * Added regularization of chromosome names using roman numerals,
    common in both S. cerevisiae and C. elegans genome communities.
    Thanks to @scottcain for assistance (pull #1376, @cmdcolin)
+
+ * Added ability for vertical scroll events to bubble out of the jbrowse
+   div or iframe, which can be more intuitive in embedded jbrowse's.
+   Otherwise, the GenomeView stopped all vertical scroll events in it's
+   area. If you need the old behavior use `alwaysStopScrollBubble`.
+   (@cmdcolin, pull #1373)
 
 ## Bug fixes
 
@@ -42,14 +48,14 @@
  * Fixed an issue with NeatHTMLFeatures when zoomed out. Thanks to
    @abretaud for the implementation and fix (pull #1368).
 
- * Restore ability to access widest zoom level from bigwig. Thanks
+ * Restored ability to access widest zoom level from bigwig. Thanks
    to @lukaw3d for noticing and debugging (issue #1375, @cmdcolin)
 
- * Fix some minor parsing of 'b' type data series in CRAM files,
+ * Fixed some minor parsing of 'b' type data series in CRAM files,
    which happens when CRAM is not using reference based compression
    so it is uncommon (@cmdcolin)
 
- * Add some more checks for track types for combination tracks (issue
+ * Added some more checks for track types for combination tracks (issue
    #1361)
 
 # Release 1.16.4     2019-04-10 16:58:02 UTC

--- a/src/JBrowse/GenomeView.js
+++ b/src/JBrowse/GenomeView.js
@@ -685,11 +685,20 @@ wheelScroll: function( event ) {
     delta.x = Math.round( delta.x * 2 );
     delta.y = Math.round( delta.y );
 
-    if( delta.x )
+    var didScroll = false
+
+    if( delta.x ) {
         this.keySlideX( -delta.x );
-    if( delta.y )
+    }
+    if( delta.y ) {
         // 60 pixels per mouse wheel event
-        this.setY( this.getY() - delta.y );
+        var prevY = this.getY()
+        var currY = this.setY( prevY - delta.y );
+        // check if clamping happened
+        if(currY !== prevY) {
+            didScroll = true
+        }
+    }
 
     //the timeout is so that we don't have to run showVisibleBlocks
     //for every scroll wheel click (we just wait until so many ms
@@ -705,7 +714,8 @@ wheelScroll: function( event ) {
         this.wheelScrollTimeout = null;
     }, 100));
 
-    dojo.stopEvent(event);
+    // allow event to bubble out of iframe for example
+    if(didScroll) dojo.stopEvent(event);
 },
 
 getX: function() {

--- a/src/JBrowse/GenomeView.js
+++ b/src/JBrowse/GenomeView.js
@@ -715,7 +715,7 @@ wheelScroll: function( event ) {
     }, 100));
 
     // allow event to bubble out of iframe for example
-    if(didScroll || this.config.alwaysStopScrollBubble) dojo.stopEvent(event);
+    if(didScroll || this.browser.config.alwaysStopScrollBubble) dojo.stopEvent(event);
 },
 
 getX: function() {

--- a/src/JBrowse/GenomeView.js
+++ b/src/JBrowse/GenomeView.js
@@ -715,7 +715,7 @@ wheelScroll: function( event ) {
     }, 100));
 
     // allow event to bubble out of iframe for example
-    if(didScroll) dojo.stopEvent(event);
+    if(didScroll || this.config.alwaysStopScrollBubble) dojo.stopEvent(event);
 },
 
 getX: function() {


### PR DESCRIPTION
This PR addresses a possible long standing need to allow scroll wheel events to bubble

Here is an example page that uses jbrowse in an iframe embedding

```
<html>
  <head>

  <body>
        <div style="width: 100%; height:100px; background: grey">
        <h1>MyWebSite header</h1>
        <p>Main menu, about, help, etc</p>
        </div>
        <iframe id="jbrowse_iframe" width="100%" height="800px" src="index.html"></iframe>

        <div style="width: 100%; height:200px; background: grey">
        <h1>MyWebSite footer</h1>
    <p>(c) 1999</p>
    </div>
  </body>
</html>
```

If you look at this page without this PR added, any vertical scrolling inside the jbrowse iframe (or div, if it was embedded as a div) would not work, because jbrowse manually stops it. <Edit: Actually not anywhere in the jbrowse iframe, just in the GenomeView panel>

This PR proposes changing it to only stop it if the vertical scroll did anything in the jbrowse content pane area
 
CC @garrettjstevens @enuggetry  @scottcain 

I think that this scenario can enhance usages in embeddings

I would be curious if people could try downloading this snippet of embedding, test it out, and let me know what you think