### PR TITLE
Wait for the ready signal to fix race condition in name store

### DIFF
--- a/src/JBrowse/Store/Names/Hash.js
+++ b/src/JBrowse/Store/Names/Hash.js
@@ -127,12 +127,14 @@ return declare( HashStore,
     },
 
     // case-insensitive, and supports prefix queries like 'foo*'
-    query: function( query, options ) {
+    async query( query, options ) {
         // remove trailing asterisks from query.name
         var thisB = this;
         var name = ( query.name || '' ).toString();
 
         // lowercase the name if the store is all-lowercase
+        // wait for the ready signal to test for lower case keys
+        await this.ready
         if( this.meta.lowercase_keys )
             name = name.toLowerCase();
 


### PR DESCRIPTION
This adds a check that the meta data is ready before interpreting the lower casing argument in the meta.json

Fixes a bug raised by @scottcain 