### PR TITLE
Make VCFFeatures use fileOffset based feature IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@gmod/cram": "^1.5.3",
     "@gmod/gff": "^1.1.1",
     "@gmod/indexedfasta": "^1.0.11",
-    "@gmod/tabix": "^1.1.8",
+    "@gmod/tabix": "^1.3.2",
     "@gmod/tribble-index": "^2.0.3",
     "@gmod/twobit": "^1.1.2",
     "@gmod/vcf": "^2.0.2",

--- a/src/JBrowse/Store/SeqFeature/VCFTabix.js
+++ b/src/JBrowse/Store/SeqFeature/VCFTabix.js
@@ -101,14 +101,12 @@ return declare( [ SeqFeatureStore, DeferredStatsMixin, DeferredFeaturesMixin, In
                 regularizedReferenceName,
                 query.start,
                 query.end,
-                line => {
+                (line, fileOffset) => {
                     const variant = parser.parseLine(line)
                     const feature = new VCFFeature({
                         variant: variant,
                         parser: parser,
-                        id: variant.ID ?
-                            variant.ID[0] :
-                            `chr${variant.CHROM}_pos${variant.POS}_ref${variant.REF}_alt${variant.ALT}`
+                        id: 'vcf-'+fileOffset
                     })
                     featureCallback(feature)
                 }

--- a/tests/js_tests/spec/GFF3Tabix.spec.js
+++ b/tests/js_tests/spec/GFF3Tabix.spec.js
@@ -47,7 +47,7 @@ describe( 'GFF3 tabix store', function() {
                 let isEden = f => f.get('name') === 'EDEN'
                 expect(features.filter(isEden).length).toEqual(1)
                 let eden = features.find(isEden)
-                //console.log(JSON.stringify(eden,undefined,4))
+                // console.log(JSON.stringify(eden,undefined,4))
                 // we should still get all the subfeatures of EDEN, some of which lie
                 // entirely outside of the queried range
                 expect(JSON.stringify(eden)).toEqual(JSON.stringify(
@@ -64,7 +64,7 @@ describe( 'GFF3 tabix store', function() {
                             "id": "EDEN",
                             "name": "EDEN",
                             "note": "protein kinase",
-                            "uniqueID": "offset-873",
+                            "uniqueID": "offset-781898",
                             "subfeatures": [
                                 {
                                     "data": {
@@ -81,7 +81,7 @@ describe( 'GFF3 tabix store', function() {
                                         "name": "EDEN.1",
                                         "note": "Eden splice form 1",
                                         "index": "1",
-                                        "uniqueID": "offset-945",
+                                        "uniqueID": "offset-781970",
                                         "subfeatures": [
                                             {
                                                 "data": {
@@ -94,9 +94,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": null,
                                                     "parent": "EDEN.1",
-                                                    "uniqueID": "offset-1145"
+                                                    "uniqueID": "offset-782170"
                                                 },
-                                                "_uniqueID": "offset-1145"
+                                                "_uniqueID": "offset-782170"
                                             },
                                             {
                                                 "data": {
@@ -109,9 +109,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": "0",
                                                     "parent": "EDEN.1",
-                                                    "uniqueID": "offset-1584"
+                                                    "uniqueID": "offset-782609"
                                                 },
-                                                "_uniqueID": "offset-1584"
+                                                "_uniqueID": "offset-782609"
                                             },
                                             {
                                                 "data": {
@@ -124,9 +124,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": "0",
                                                     "parent": "EDEN.1",
-                                                    "uniqueID": "offset-2148"
+                                                    "uniqueID": "offset-783173"
                                                 },
-                                                "_uniqueID": "offset-2148"
+                                                "_uniqueID": "offset-783173"
                                             },
                                             {
                                                 "data": {
@@ -139,9 +139,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": "0",
                                                     "parent": "EDEN.1",
-                                                    "uniqueID": "offset-2627"
+                                                    "uniqueID": "offset-783652"
                                                 },
-                                                "_uniqueID": "offset-2627"
+                                                "_uniqueID": "offset-783652"
                                             },
                                             {
                                                 "data": {
@@ -154,9 +154,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": "0",
                                                     "parent": "EDEN.1",
-                                                    "uniqueID": "offset-3432"
+                                                    "uniqueID": "offset-784457"
                                                 },
-                                                "_uniqueID": "offset-3432"
+                                                "_uniqueID": "offset-784457"
                                             },
                                             {
                                                 "data": {
@@ -169,13 +169,13 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": null,
                                                     "parent": "EDEN.1",
-                                                    "uniqueID": "offset-3758"
+                                                    "uniqueID": "offset-784783"
                                                 },
-                                                "_uniqueID": "offset-3758"
+                                                "_uniqueID": "offset-784783"
                                             }
                                         ]
                                     },
-                                    "_uniqueID": "offset-945"
+                                    "_uniqueID": "offset-781970"
                                 },
                                 {
                                     "data": {
@@ -192,7 +192,7 @@ describe( 'GFF3 tabix store', function() {
                                         "name": "EDEN.2",
                                         "note": "Eden splice form 2",
                                         "index": "1",
-                                        "uniqueID": "offset-1045",
+                                        "uniqueID": "offset-782070",
                                         "subfeatures": [
                                             {
                                                 "data": {
@@ -205,9 +205,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": null,
                                                     "parent": "EDEN.2",
-                                                    "uniqueID": "offset-1203"
+                                                    "uniqueID": "offset-782228"
                                                 },
-                                                "_uniqueID": "offset-1203"
+                                                "_uniqueID": "offset-782228"
                                             },
                                             {
                                                 "data": {
@@ -220,9 +220,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": "0",
                                                     "parent": "EDEN.2",
-                                                    "uniqueID": "offset-1631"
+                                                    "uniqueID": "offset-782656"
                                                 },
-                                                "_uniqueID": "offset-1631"
+                                                "_uniqueID": "offset-782656"
                                             },
                                             {
                                                 "data": {
@@ -235,9 +235,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": "0",
                                                     "parent": "EDEN.2",
-                                                    "uniqueID": "offset-2674"
+                                                    "uniqueID": "offset-783699"
                                                 },
-                                                "_uniqueID": "offset-2674"
+                                                "_uniqueID": "offset-783699"
                                             },
                                             {
                                                 "data": {
@@ -250,9 +250,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": "0",
                                                     "parent": "EDEN.2",
-                                                    "uniqueID": "offset-3479"
+                                                    "uniqueID": "offset-784504"
                                                 },
-                                                "_uniqueID": "offset-3479"
+                                                "_uniqueID": "offset-784504"
                                             },
                                             {
                                                 "data": {
@@ -265,13 +265,13 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": null,
                                                     "parent": "EDEN.2",
-                                                    "uniqueID": "offset-3817"
+                                                    "uniqueID": "offset-784842"
                                                 },
-                                                "_uniqueID": "offset-3817"
+                                                "_uniqueID": "offset-784842"
                                             }
                                         ]
                                     },
-                                    "_uniqueID": "offset-1045"
+                                    "_uniqueID": "offset-782070"
                                 },
                                 {
                                     "data": {
@@ -288,7 +288,7 @@ describe( 'GFF3 tabix store', function() {
                                         "name": "EDEN.3",
                                         "note": "Eden splice form 3",
                                         "index": "1",
-                                        "uniqueID": "offset-1678",
+                                        "uniqueID": "offset-782703",
                                         "subfeatures": [
                                             {
                                                 "data": {
@@ -301,9 +301,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": null,
                                                     "parent": "EDEN.3",
-                                                    "uniqueID": "offset-1778"
+                                                    "uniqueID": "offset-782803"
                                                 },
-                                                "_uniqueID": "offset-1778"
+                                                "_uniqueID": "offset-782803"
                                             },
                                             {
                                                 "data": {
@@ -316,9 +316,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": null,
                                                     "parent": "EDEN.3",
-                                                    "uniqueID": "offset-2195"
+                                                    "uniqueID": "offset-783220"
                                                 },
-                                                "_uniqueID": "offset-2195"
+                                                "_uniqueID": "offset-783220"
                                             },
                                             {
                                                 "data": {
@@ -331,9 +331,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": "0",
                                                     "parent": "EDEN.3",
-                                                    "uniqueID": "offset-2327"
+                                                    "uniqueID": "offset-783352"
                                                 },
-                                                "_uniqueID": "offset-2327"
+                                                "_uniqueID": "offset-783352"
                                             },
                                             {
                                                 "data": {
@@ -346,9 +346,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": "1",
                                                     "parent": "EDEN.3",
-                                                    "uniqueID": "offset-2721"
+                                                    "uniqueID": "offset-783746"
                                                 },
-                                                "_uniqueID": "offset-2721"
+                                                "_uniqueID": "offset-783746"
                                             },
                                             {
                                                 "data": {
@@ -361,9 +361,9 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": "1",
                                                     "parent": "EDEN.3",
-                                                    "uniqueID": "offset-3385"
+                                                    "uniqueID": "offset-784410"
                                                 },
-                                                "_uniqueID": "offset-3385"
+                                                "_uniqueID": "offset-784410"
                                             },
                                             {
                                                 "data": {
@@ -376,19 +376,20 @@ describe( 'GFF3 tabix store', function() {
                                                     "strand": 1,
                                                     "phase": null,
                                                     "parent": "EDEN.3",
-                                                    "uniqueID": "offset-3699"
+                                                    "uniqueID": "offset-784724"
                                                 },
-                                                "_uniqueID": "offset-3699"
+                                                "_uniqueID": "offset-784724"
                                             }
                                         ]
                                     },
-                                    "_uniqueID": "offset-1678"
+                                    "_uniqueID": "offset-782703"
                                 }
                             ]
                         },
                         "_uniqueID": "EDEN",
                         "_reg_seq_id": "ctga"
                     }
+
 
                 ))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,16 +251,17 @@
     "@gmod/bgzf-filehandle" "^1.2.4"
     es6-promisify "^6.0.1"
 
-"@gmod/tabix@^1.1.8":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@gmod/tabix/-/tabix-1.2.0.tgz#f0043f89645afefac375844cd6c2b501dd9d1198"
-  integrity sha512-WcFeG/Bx9JCoImftCKZiPT7uUxz3sUhVCvLNKWmU+8jqqhpsqC2DNmgGYN5ve9PqsDTlwFLj1y1SFPINiI5ZgQ==
+"@gmod/tabix@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@gmod/tabix/-/tabix-1.3.2.tgz#48f782d516561bc727aa8bab3e04a6c4a9113440"
+  integrity sha512-eH0iQdj+Eitr+VtEs2jvqhsIRxO8dDdAEw2AaGNB/Xi4OIxDeP8i8PZkmYDxX8KiBKlTCqXAafSSGbZH5WfMkg==
   dependencies:
     "@babel/runtime-corejs2" "^7.3.1"
+    "@gmod/bgzf-filehandle" "^1.3.0"
+    abortable-promise-cache "^1.0.1"
     es6-promisify "^6.0.1"
     generic-filehandle "^2.0.0"
     long "^4.0.0"
-    pako "1.0.10"
     quick-lru "^2.0.0"
 
 "@gmod/tribble-index@^2.0.3":
@@ -6286,7 +6287,7 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-pako@1.0.10, pako@^1.0.10, pako@~1.0.5:
+pako@^1.0.10, pako@~1.0.5:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==


### PR DESCRIPTION
The VCFFeature apparently never used full line hash so it wasn't making a best effort to de-duplicate features

Nevertheless, now it doesn't need to hash the whole line it can use the fileOffset based IDs since tabix 1.3.2


