### PR TITLE
Allow initializing the popup text with a predefined result

### DIFF
--- a/src/JBrowse/View/FeatureGlyph/_FeatureLabelMixin.js
+++ b/src/JBrowse/View/FeatureGlyph/_FeatureLabelMixin.js
@@ -17,8 +17,8 @@ return declare( FeatureDescriptionMixin,  {
      * feature's label text, and trim it if necessary to fit within
      * the track's maxFeatureGlyphExpansion limit.
      */
-    makeFeatureLabel: function( feature, fRect ) {
-        var text = this.getFeatureLabel( feature );
+    makeFeatureLabel: function( feature, fRect, text ) {
+        var text = text || this.getFeatureLabel( feature );
         if( ! text )
             return null;
         text = ''+text;
@@ -33,8 +33,8 @@ return declare( FeatureDescriptionMixin,  {
      * feature's description text, and trim it if necessary to fit
      * within the track's maxFeatureGlyphExpansion limit.
      */
-    makeFeatureDescriptionLabel: function( feature, fRect ) {
-        var text = this.getFeatureDescription( feature );
+    makeFeatureDescriptionLabel: function( feature, fRect, text ) {
+        var text = text || this.getFeatureDescription( feature );
         if( ! text )
             return null;
         text = ''+text;

--- a/src/JBrowse/View/Track/CanvasFeatures.js
+++ b/src/JBrowse/View/Track/CanvasFeatures.js
@@ -898,8 +898,12 @@ return declare(
                     var renderTooltip = dojo.hitch( this, function() {
                         if( !this.labelTooltip )
                             return;
-                        var label = fRect.label || fRect.glyph.makeFeatureLabel( feature );
-                        var description = fRect.description || fRect.glyph.makeFeatureDescriptionLabel( feature );
+
+                        var text
+                        text = this.template( feature, this._evalConf( context, (this.config.onClick||{}).label, "label" ) )
+                        var label = fRect.label || fRect.glyph.makeFeatureLabel( feature, undefined, text )
+                        text = this.template( feature, this._evalConf( context, (this.config.onClick||{}).label, "description" ) )
+                        var description = fRect.description || fRect.glyph.makeFeatureDescriptionLabel( feature, undefined, text )
 
                         if( ( !label && !description ) )
                             return;
@@ -910,8 +914,8 @@ return declare(
                         }
                         this.ignoreTooltipTimeout = true;
                         this.labelTooltip.style.display = 'block';
-                        var labelSpan = this.labelTooltip.childNodes[0],
-                            descriptionSpan = this.labelTooltip.childNodes[1];
+                        var labelSpan = this.labelTooltip.childNodes[0]
+                        var descriptionSpan = this.labelTooltip.childNodes[1];
 
                         if( this.config.onClick&&this.config.onClick.label ) {
                             var context = lang.mixin( { track: this, feature: feature, callbackArgs: [ this, feature ] } );

--- a/src/JBrowse/View/Track/CanvasFeatures.js
+++ b/src/JBrowse/View/Track/CanvasFeatures.js
@@ -899,6 +899,7 @@ return declare(
                         if( !this.labelTooltip )
                             return;
 
+                        var context = lang.mixin( { track: this, feature: feature, callbackArgs: [ this, feature ] } );
                         var text
                         text = this.template( feature, this._evalConf( context, (this.config.onClick||{}).label, "label" ) )
                         var label = fRect.label || fRect.glyph.makeFeatureLabel( feature, undefined, text )
@@ -918,7 +919,6 @@ return declare(
                         var descriptionSpan = this.labelTooltip.childNodes[1];
 
                         if( this.config.onClick&&this.config.onClick.label ) {
-                            var context = lang.mixin( { track: this, feature: feature, callbackArgs: [ this, feature ] } );
                             labelSpan.style.display = 'block';
                             labelSpan.style.font = label.font;
                             labelSpan.style.color = label.fill;


### PR DESCRIPTION
This enables custom mouseovers to be evaluated when there is no feature label that could be calculated via the default logic for calculating the feature label, e.g. there is no feature name or ID

CC @scottcain 

