### PR TITLE
Fix clone object

### DIFF
--- a/src/JBrowse/View/Track/_ExportMixin.js
+++ b/src/JBrowse/View/Track/_ExportMixin.js
@@ -70,7 +70,8 @@ return declare( null, {
 
         var highlightedRegion = this.browser.getHighlight();
         if( highlightedRegion ) {
-            regions.unshift( lang.mixin( lang.clone( highlightedRegion ), { description: "Highlighted region", name: "highlight" } ) );
+            const { start, end, ref } = highlightedRegion
+            regions.unshift({ start, end, ref, description: "Highlighted region", name: "highlight" });
         }
 
         return regions;


### PR DESCRIPTION
The lang.clone on the highlightedRegion object tries to clone the track reference that it has and that results in error described in #1488 

This just grabs a couple required things from the highlightedRegion object