### PR TITLE
Better formatting of example plugin directory

### DIFF
--- a/docs/site/plugins.md
+++ b/docs/site/plugins.md
@@ -81,14 +81,13 @@ return declare( JBrowsePlugin,
 #### Example plugin directory contents
 
 
-   plugins/MyPlugin/js
-   plugins/MyPlugin/js/main.js
-   plugins/MyPlugin/js/MyPlugin.profile.js
-   plugins/MyPlugin/css
-   plugins/MyPlugin/css/main.css
-   plugins/MyPlugin/img
-   plugins/MyPlugin/img/myimage.png
-   plugins/MyPlugin/js
+-   plugins/MyPlugin/js
+    -   plugins/MyPlugin/js/main.js
+    -   plugins/MyPlugin/js/MyPlugin.profile.js
+-   plugins/MyPlugin/css
+    -   plugins/MyPlugin/css/main.css
+-   plugins/MyPlugin/img
+    -   plugins/MyPlugin/img/myimage.png
 
 The bin/new-plugin.pl will initialize a directory structure for you, e.g. run
 


### PR DESCRIPTION
Added a little bit of formatting to increase the readability of the Example plugin directory contents file list.

Before:
<img width="1274" alt="Screenshot 2020-05-13 at 13 47 18" src="https://user-images.githubusercontent.com/3518980/81809148-2c6cab00-9521-11ea-8d07-41e708126277.png">

After:
<img width="922" alt="Screenshot 2020-05-13 at 13 54 47" src="https://user-images.githubusercontent.com/3518980/81809238-558d3b80-9521-11ea-95b4-78bfdc7a83db.png">

