### PR TITLE
Fix ability to use locally opened tracks in combination tracks

### DIFF
--- a/src/JBrowse/View/FileDialog/TrackList.js
+++ b/src/JBrowse/View/FileDialog/TrackList.js
@@ -99,6 +99,7 @@ _makeTrackConfs: function() {
 
         this.trackConfs[ n ] =  {
             store: this.storeConfs[n],
+            storeClass: this.storeConfs[n].type,
             label: n,
             key: n.replace(/_\d+$/,'').replace(/_/g,' '),
             type: trackType,


### PR DESCRIPTION
This fixes the ability to use locally opened tracks in a combination track, since storeClass is snooped upon. 