### PR TITLE
changing the version on the dev branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gmod/jbrowse",
   "main": "browser/main.js",
-  "version": "1.16.11-alpha.0",
+  "version": "1.16-dev",
   "description": "JBrowse - client-side genome browser",
   "repository": "https://github.com/GMOD/jbrowse.git",
   "scripts": {


### PR DESCRIPTION
to not include the minor version number. what was there is very out of date; this change is much better, since it can be seen in the "about" for jbrowse when it's built from dev (which I do frequently).

# Submitting a pull request

Please base your pull request based on the "dev" branch of JBrowse

The default branch is "master" but this contains the last stable release, and new pull requests should be based off of "dev"

Then set the base branch to "dev" on GitHub also


