### PR TITLE
Update jbrowse 1 website header to refer to jbrowse 2

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -97,7 +97,7 @@ const siteVariables = {
 
 
 const siteConfig = {
-  title: 'JBrowse',
+  title: 'JBrowse 1',
   tagline: 'A fast, embeddable genome browser built with HTML5 and JavaScript',
   url: 'https://jbrowse.org',
   baseUrl: '/',
@@ -112,7 +112,12 @@ const siteConfig = {
     {page: 'developers', label: 'Developers'},
     {page: 'contact', label: 'Contact'},
     {page: 'references', label: 'References'},
-    {page: 'help', label: 'Help'}
+    {page: 'help', label: 'Help'},
+    {
+            href: "https://jbrowse.org/jb2/",
+            label: "Looking for JBrowse 2?",
+            external: true,
+    },
   ],
 
   footerIcon: 'img/jbrowse.png',


### PR DESCRIPTION
Possible fix for https://github.com/GMOD/jbrowse-components/issues/2036

Looks like this


![localhost_3001_](https://user-images.githubusercontent.com/6511937/120700231-6a67a480-c47f-11eb-9114-aae2cd41c6c8.png)
