### PR TITLE
Fix runtime track add in BioNano plugin

### DIFF
--- a/src/JBrowse/View/TrackList/Hierarchical.js
+++ b/src/JBrowse/View/TrackList/Hierarchical.js
@@ -180,7 +180,7 @@ return declare(
                                  lang.setObject( 'collapsed.'+categoryPath, !newval, thisB.state );
                                  thisB._saveState();
                              });
-                    obj.pane.addChild(c, inStartup ? undefined : 1 );
+                    obj.pane.addChild(c);
                     return { parent: obj, pane: c, categories: {}, tracks: {} };
                 }.call(thisB));
 


### PR DESCRIPTION
This is a bugfix for jbrowse 1 for using the BioNano plugin. I did not investigate why this fixes the issue because it is somewhat odd to me, but it does

this follows up on discussions on gitter for help with cc @yumisims for Sanger/tree of life work


To test this branch, you can follow steps from https://gist.github.com/cmdcolin/b47c8e22685bf2f6ed4d982c95f164c3 and just add the added step to `git checkout fix_runtime_track_add` after the git clone



## Detailed

I am not sure why there is a crash, but the "insertIndex" paramter of addChild causes it to crash for some reason https://github.com/dojo/dijit/blob/f82f5f2e6517acd0142ab19292a097072feea5dd/_Container.js#L26

The only behavior of this addChild paramter is to I believe prepend(?) to the track selector instead of append, but it is for some reason causing the crash in this case. given that it's cosmetic, I recommend adding this branch as a hotfix @yumisims