### PR TITLE
Update tutorial.md

### DIFF
--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -52,7 +52,7 @@ With genometools, it has added validation checking mechanisms that are helpful
 
 With normal GNU sort you can try something like this
 
-    (grep ^"#" data/volvox.gff3; grep -v ^"#" data/volvox.gff3 | grep -v "^$" | grep "\t" | sort -k1,1 -k4,4n) > data/volvox.sorted.gff3
+    (grep ^"#" data/volvox.gff3; grep -v ^"#" data/volvox.gff3 | grep -v "^$" | sort -k1,1 -k4,4n) > data/volvox.sorted.gff3
 
 If you are running on a custom dataset instead of this volvox one, then you should be confident that your GFF is properly formatted to use the GNU sort, otherwise try `brew install genometools` and use the genometools sort
 


### PR DESCRIPTION
In sorting gff3 files before tabix, grep "\t" perhaps intend to select only lines containing a tab. However, because string quote and escape does not work in standard shells like scripting languages and the result would be deleting lines not containing a t, which will result in errors loading the track on JBrowse. A good gff3 file do not contain a line without tab other than comment lines starting with a #. So this part (i.e. grep "\t" through the pipe)  can be removed and thus should be removed.