### PR TITLE
ci: migrate LizardByte/setup-python-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           npm install -g yarn
 
-      - uses: LizardByte/setup-python-action@master
+      - uses: LizardByte/actions/actions/setup_python@master
         with:
           python-version: '2.7'
 


### PR DESCRIPTION
LizardByte/setup-python-action is deprecated and has moved to LizardByte/actions.
