### PR TITLE
Add the missing `watch` script and drop stale README build advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,10 @@ See
 
 ## Note: If you are using plugins or installing from GitHub
 
-You may need to use node <=14 (e.g. node >=15 may fail) due to node-sass not
-compiling on newer node versions easily. See
-https://github.com/GMOD/jbrowse/pull/1607 for details
-
-2025 update: The latest master branch on GitHub removed node-sass so can be
-built with newer versions of node.js e.g. node 22 (not node 23 yet though). You
-may need to run `export NODE_OPTIONS=--openssl-legacy-provider` before
-`./setup.sh` however
+JBrowse 1.17.0 removed node-sass, which used to be what stopped the build from
+working on newer versions of node. Building from a GitHub clone now works on
+node 12 through node 24. You do not need to set `NODE_OPTIONS` by hand: the
+build passes `--openssl-legacy-provider` itself on node 17 and newer.
 
 # Installing JBrowse
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "node build/run-webpack.js webpack-dev-server",
     "start": "node build/run-webpack.js webpack-dev-server",
     "build": "node build/run-webpack.js webpack",
+    "watch": "node build/run-webpack.js webpack --watch",
     "build-electron": "electron-packager . JBrowse --overwrite --icon=browser/icons/jbrowse",
     "hint": "npm run lint",
     "lint": "eslint src/JBrowse tests/js_tests/spec"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,15 @@
 {{$NEXT}}
 
+## Developer
+
+- Add the `watch` script that README and the FAQ have always told developers to
+  run. `yarn watch` / `npm run watch` did not actually exist in package.json
+
+- Drop stale README advice: node-sass has been gone since 1.17.0, so the "use
+  node <=14" warning no longer applies, and the build now sets
+  `--openssl-legacy-provider` itself on node 17+ rather than asking you to
+  export `NODE_OPTIONS` by hand
+
 
 # Release 1.17.1     2026-07-16 16:13:47 UTC
 


### PR DESCRIPTION
## Problem

`README.md` and `docs/site/faq.md` both tell developers to run `yarn watch` / `npm run watch` while editing source. The FAQ even explains what it does:

> In modify JBrowse source code you must use `npm run watch` (equivalently `yarn watch`) to watch for changes to the codebase. This uses `webpack -w` in the background...

**But there is no `watch` script in `package.json`**, so both commands just error out. Anyone following the developer instructions hits a dead end.

The README's build note was also stale in both directions:

- It warns to use *node <=14* because of node-sass — but node-sass was removed in 1.17.0.
- It says you "may need to run `export NODE_OPTIONS=--openssl-legacy-provider`" — but `build/run-webpack.js` has been injecting that automatically for node >=17 since then.

## Changes

- Add `"watch": "node build/run-webpack.js webpack --watch"`, mirroring `build` so it routes through `run-webpack.js` and inherits the automatic `--openssl-legacy-provider` handling. This makes the already-documented workflow real rather than deleting it from the docs.
- Replace the stale README note with what is actually true today.

## Testing

- `npm run watch` builds `dist/` with 0 errors and stays running to watch, as the FAQ describes.
- The webpack build itself verified on **node 12.22** and **node 24** (the README's "node 12 through node 24" claim is grounded at both ends).
- `prettier --check` clean on `package.json` and `README.md`. `release-notes.md` was already prettier-unclean at HEAD, so it is deliberately not reformatted here.

No install-path changes: `setup.sh`, the lockfile, and CI are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGHDpMp2TPeDdriLJoYNYf